### PR TITLE
Add knowledge-driven LLM match analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ DISCORD_CLIENT_ID=your-discord-client-id
 LLM_API_KEY=your-zen-api-key
 LLM_API_URL=https://api.opencode.ai/v1/chat/completions
 LLM_MODEL=deepseek-chat
+LLM_KNOWLEDGE_EXTERNAL=1
+# Optional absolute or repo-relative path to custom LoL knowledge JSON
+# LLM_KNOWLEDGE_FILE=app/analysis/knowledge/game_knowledge.json
 
 # Admin
 ADMIN_EMAIL=your-email@example.com

--- a/app/admin/routes.py
+++ b/app/admin/routes.py
@@ -97,6 +97,8 @@ def test_llm():
             if not analysis_data:
                 flash('Failed to analyze the selected match.', 'error')
                 return redirect(url_for('admin.test_llm'))
+            analysis_data['platform_region'] = region
+            analysis_data['player_puuid'] = puuid
 
             return render_template('admin/test_llm.html',
                 analysis_data=analysis_data,

--- a/app/analysis/engine.py
+++ b/app/analysis/engine.py
@@ -100,6 +100,7 @@ def analyze_match(watcher: LolWatcher, region: str, puuid: str, match_id: str) -
             return None
 
         player_data = match_detail['info']['participants'][player_index]
+        player_item_ids = [player_data.get(f'item{i}', 0) for i in range(7) if player_data.get(f'item{i}', 0)]
 
         kda = (player_data['kills'] + player_data['assists']) / max(1, player_data['deaths'])
         gold_earned = player_data['goldEarned']
@@ -121,7 +122,10 @@ def analyze_match(watcher: LolWatcher, region: str, puuid: str, match_id: str) -
         participants = []
         for p in match_detail['info']['participants']:
             participants.append({
+                'puuid': p.get('puuid', ''),
+                'summoner_id': p.get('summonerId', ''),
                 'champion': p['championName'],
+                'champion_id': p.get('championId'),
                 'summoner_name': p.get('riotIdGameName') or p.get('summonerName', ''),
                 'tagline': p.get('riotIdTagline', ''),
                 'team_id': p.get('teamId', 0),
@@ -135,6 +139,8 @@ def analyze_match(watcher: LolWatcher, region: str, puuid: str, match_id: str) -
                 'total_damage': p.get('totalDamageDealtToChampions', p.get('totalDamageDealt', 0)),
                 'cs': p.get('totalMinionsKilled', 0) + p.get('neutralMinionsKilled', 0),
                 'vision_score': p.get('visionScore', 0),
+                'level': p.get('champLevel', 0),
+                'item_ids': [p.get(f'item{i}', 0) for i in range(7) if p.get(f'item{i}', 0)],
             })
 
         game_start_timestamp = match_detail['info'].get('gameStartTimestamp')
@@ -158,6 +164,11 @@ def analyze_match(watcher: LolWatcher, region: str, puuid: str, match_id: str) -
             'game_duration': round(game_duration_minutes, 1),
             'recommendations': generate_recommendations(player_data, match_detail),
             'queue_type': queue_type,
+            'queue_id': queue_id,
+            'routing_region': region,
+            'player_puuid': puuid,
+            'player_summoner_id': player_data.get('summonerId', ''),
+            'item_ids': player_item_ids,
             'participants': participants,
             'game_start_timestamp': game_start_timestamp,
             'player_position': player_position,

--- a/app/analysis/knowledge/game_knowledge.json
+++ b/app/analysis/knowledge/game_knowledge.json
@@ -1,0 +1,51 @@
+{
+  "default_patch_notes": [
+    "If explicit patch notes are not loaded for the detected version, do not invent specific buffs or nerfs.",
+    "Prioritize concrete in-match evidence (item timings, damage share, lane stats, comp shape) over patch speculation."
+  ],
+  "champion_phase_overrides": {
+    "kayle": {
+      "early": "weak",
+      "mid": "average",
+      "late": "strong",
+      "notes": "Scaling pick: protect lanes and resources until key level/item breakpoints."
+    },
+    "draven": {
+      "early": "strong",
+      "mid": "average",
+      "late": "average",
+      "notes": "Snowball-focused lane bully that needs tempo conversion."
+    },
+    "nasus": {
+      "early": "weak",
+      "mid": "average",
+      "late": "strong",
+      "notes": "Farm-to-scale profile with strong side lane pressure later."
+    },
+    "lee sin": {
+      "early": "strong",
+      "mid": "strong",
+      "late": "average",
+      "notes": "Early agency jungler that benefits from proactive tempo and setup."
+    }
+  },
+  "synergy_pairs": [
+    {
+      "champions": ["Yasuo", "Malphite"],
+      "reason": "Reliable knock-up chain enables clean all-in execution."
+    },
+    {
+      "champions": ["Miss Fortune", "Amumu"],
+      "reason": "Layered AoE engage can decide grouped objective fights."
+    },
+    {
+      "champions": ["Kai'Sa", "Nautilus"],
+      "reason": "Point-and-click engage gives dependable dive access."
+    }
+  ],
+  "patch_notes": {
+    "15": [
+      "Use objective setup and reset timing as a major coaching lens for post-lane decisions."
+    ]
+  }
+}

--- a/app/analysis/llm.py
+++ b/app/analysis/llm.py
@@ -1,10 +1,55 @@
-"""LLM-powered match analysis using OpenCode Zen API (OpenAI-compatible)."""
+"""LLM-powered match analysis with a knowledge-enriched prompt pipeline."""
 
+import json
 import logging
+import re
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import median
+
 import requests
 from flask import current_app
+from riotwatcher import ApiError
+
+from app.analysis.riot_api import get_watcher
 
 logger = logging.getLogger(__name__)
+
+_TIER_ORDER = {
+    'IRON': 0,
+    'BRONZE': 1,
+    'SILVER': 2,
+    'GOLD': 3,
+    'PLATINUM': 4,
+    'EMERALD': 5,
+    'DIAMOND': 6,
+    'MASTER': 7,
+    'GRANDMASTER': 8,
+    'CHALLENGER': 9,
+}
+_DIVISION_ORDER = {'IV': 1, 'III': 2, 'II': 3, 'I': 4}
+_RANKED_QUEUE_MAP = {
+    'Ranked Solo': 'RANKED_SOLO_5x5',
+    'Ranked Flex': 'RANKED_FLEX_SR',
+}
+_DDRAGON_VERSIONS_URL = 'https://ddragon.leagueoflegends.com/api/versions.json'
+_DDRAGON_CHAMPIONS_URL = 'https://ddragon.leagueoflegends.com/cdn/{patch}/data/en_US/champion.json'
+_DDRAGON_ITEMS_URL = 'https://ddragon.leagueoflegends.com/cdn/{patch}/data/en_US/item.json'
+_LOCAL_KNOWLEDGE_DEFAULT = Path(__file__).with_name('knowledge').joinpath('game_knowledge.json')
+
+_CACHE_LOCK = threading.Lock()
+_PATCH_CACHE = {'expires_at': 0.0, 'value': ''}
+_DDRAGON_CACHE = {}
+_RANK_CACHE = {}
+_LOCAL_KNOWLEDGE_CACHE = {'path': None, 'mtime': None, 'data': {}}
+
+
+def _external_knowledge_enabled() -> bool:
+    """Whether remote knowledge fetches are enabled for this environment."""
+    default = not current_app.config.get('TESTING', False)
+    return bool(current_app.config.get('LLM_KNOWLEDGE_EXTERNAL', default))
 
 
 def _format_position(pos: str) -> str:
@@ -12,16 +57,652 @@ def _format_position(pos: str) -> str:
     return {'TOP': 'Top', 'JUNGLE': 'Jungle', 'MIDDLE': 'Mid', 'BOTTOM': 'Bot', 'UTILITY': 'Support'}.get(pos, pos)
 
 
+def _normalize_text(value: str) -> str:
+    return re.sub(r'[^a-z0-9]+', '', (value or '').lower())
+
+
+def _strip_html(text: str) -> str:
+    return re.sub(r'<[^>]+>', '', text or '').replace('\n', ' ').strip()
+
+
+def _clamp(value: int, minimum: int, maximum: int) -> int:
+    return max(minimum, min(maximum, value))
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float:
+    return numerator / denominator if denominator else 0.0
+
+
+def _safe_percentage(wins: int, losses: int) -> float:
+    total = wins + losses
+    return round((wins * 100) / total, 1) if total else 0.0
+
+
+def _participant_kda(participant: dict) -> float:
+    return round(_safe_ratio(participant.get('kills', 0) + participant.get('assists', 0), max(1, participant.get('deaths', 0))), 2)
+
+
+def _participant_metrics(participant: dict, duration_minutes: float) -> dict:
+    return {
+        'kda': _participant_kda(participant),
+        'gpm': round(_safe_ratio(participant.get('gold_earned', 0), duration_minutes), 2),
+        'dpm': round(_safe_ratio(participant.get('total_damage', 0), duration_minutes), 2),
+        'cspm': round(_safe_ratio(participant.get('cs', 0), duration_minutes), 2),
+        'vpm': round(_safe_ratio(participant.get('vision_score', 0), duration_minutes), 2),
+    }
+
+
+def _median_metric(metric_dicts: list[dict], key: str) -> float:
+    values = [m[key] for m in metric_dicts if key in m]
+    return round(median(values), 2) if values else 0.0
+
+
+def _describe_delta(player_value: float, baseline_value: float, label: str, unit: str = '') -> str:
+    delta = round(player_value - baseline_value, 2)
+    if abs(delta) < 0.01:
+        return f'{label}: on par ({player_value}{unit})'
+    direction = 'above' if delta > 0 else 'below'
+    return f'{label}: {abs(delta)}{unit} {direction} baseline ({player_value}{unit} vs {baseline_value}{unit})'
+
+
+def _rank_queue_for_analysis(analysis: dict) -> str:
+    return _RANKED_QUEUE_MAP.get(analysis.get('queue_type', ''), '')
+
+
+def _rank_score(entry: dict) -> float:
+    tier = (entry.get('tier') or '').upper()
+    division = (entry.get('rank') or '').upper()
+    lp = entry.get('leaguePoints', 0) or 0
+    return (_TIER_ORDER.get(tier, -1) * 100) + (_DIVISION_ORDER.get(division, 0) * 10) + (lp / 100)
+
+
+def _format_rank_entry(entry: dict | None) -> str:
+    if not entry:
+        return 'Unranked/Unavailable'
+    tier = entry.get('tier', '?')
+    rank = entry.get('rank', '')
+    lp = entry.get('leaguePoints', 0)
+    wins = entry.get('wins', 0)
+    losses = entry.get('losses', 0)
+    wr = _safe_percentage(wins, losses)
+    return f'{tier} {rank} ({lp} LP, {wr}% WR)'
+
+
+def _choose_rank_entry(entries: list[dict], rank_queue: str) -> dict | None:
+    if not entries:
+        return None
+    if rank_queue:
+        for entry in entries:
+            if entry.get('queueType') == rank_queue:
+                return entry
+    return entries[0]
+
+
+def _find_player_and_teams(participants: list[dict]) -> tuple[dict | None, list[dict], list[dict]]:
+    player = next((p for p in participants if p.get('is_player')), None)
+    if not player:
+        return None, [], []
+    team_id = player.get('team_id')
+    allies = [p for p in participants if p.get('team_id') == team_id]
+    enemies = [p for p in participants if p.get('team_id') != team_id]
+    return player, allies, enemies
+
+
+def _knowledge_file_path() -> Path:
+    configured = (current_app.config.get('LLM_KNOWLEDGE_FILE') or '').strip()
+    return Path(configured) if configured else _LOCAL_KNOWLEDGE_DEFAULT
+
+
+def _load_local_knowledge() -> dict:
+    path = _knowledge_file_path()
+    if not path.exists():
+        return {}
+    try:
+        mtime = path.stat().st_mtime
+    except OSError:
+        return {}
+    with _CACHE_LOCK:
+        if _LOCAL_KNOWLEDGE_CACHE['path'] == str(path) and _LOCAL_KNOWLEDGE_CACHE['mtime'] == mtime:
+            return _LOCAL_KNOWLEDGE_CACHE['data']
+    try:
+        data = json.loads(path.read_text(encoding='utf-8'))
+        if not isinstance(data, dict):
+            data = {}
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Failed to load local LoL knowledge file: %s", path)
+        data = {}
+    with _CACHE_LOCK:
+        _LOCAL_KNOWLEDGE_CACHE['path'] = str(path)
+        _LOCAL_KNOWLEDGE_CACHE['mtime'] = mtime
+        _LOCAL_KNOWLEDGE_CACHE['data'] = data
+    return data
+
+
+def _fetch_current_patch() -> str:
+    if not _external_knowledge_enabled():
+        return ''
+    now = time.time()
+    with _CACHE_LOCK:
+        if _PATCH_CACHE['expires_at'] > now:
+            return _PATCH_CACHE['value']
+    patch = ''
+    try:
+        resp = requests.get(_DDRAGON_VERSIONS_URL, timeout=5)
+        if resp.status_code == 200:
+            versions = resp.json()
+            if isinstance(versions, list) and versions:
+                patch = versions[0]
+    except requests.RequestException:
+        patch = ''
+    with _CACHE_LOCK:
+        _PATCH_CACHE['value'] = patch
+        _PATCH_CACHE['expires_at'] = now + 6 * 3600
+    return patch
+
+
+def _fetch_ddragon_data(patch: str) -> tuple[dict, dict]:
+    """Return (champion_lookup, item_lookup) keyed by normalized aliases/id."""
+    if not patch or not _external_knowledge_enabled():
+        return {}, {}
+    now = time.time()
+    with _CACHE_LOCK:
+        cached = _DDRAGON_CACHE.get(patch)
+        if cached and cached['expires_at'] > now:
+            return cached['champions'], cached['items']
+    champion_lookup: dict[str, dict] = {}
+    item_lookup: dict[int, dict] = {}
+    try:
+        champ_resp = requests.get(_DDRAGON_CHAMPIONS_URL.format(patch=patch), timeout=6)
+        item_resp = requests.get(_DDRAGON_ITEMS_URL.format(patch=patch), timeout=6)
+        if champ_resp.status_code == 200:
+            champ_data = champ_resp.json().get('data', {})
+            if isinstance(champ_data, dict):
+                for champ in champ_data.values():
+                    aliases = {
+                        _normalize_text(champ.get('id', '')),
+                        _normalize_text(champ.get('name', '')),
+                        _normalize_text(champ.get('key', '')),
+                    }
+                    for alias in aliases:
+                        if alias:
+                            champion_lookup[alias] = champ
+        if item_resp.status_code == 200:
+            items = item_resp.json().get('data', {})
+            if isinstance(items, dict):
+                for item_id, item in items.items():
+                    try:
+                        item_lookup[int(item_id)] = item
+                    except (TypeError, ValueError):
+                        continue
+    except requests.RequestException:
+        champion_lookup = {}
+        item_lookup = {}
+    with _CACHE_LOCK:
+        _DDRAGON_CACHE[patch] = {
+            'expires_at': now + 6 * 3600,
+            'champions': champion_lookup,
+            'items': item_lookup,
+        }
+    return champion_lookup, item_lookup
+
+
+def _resolve_champion(champion_name: str, champion_lookup: dict) -> dict | None:
+    return champion_lookup.get(_normalize_text(champion_name))
+
+
+def _phase_label(level: int) -> str:
+    return {0: 'weak', 1: 'average', 2: 'strong'}.get(level, 'average')
+
+
+def _champion_phase_profile(champion: dict | None, overrides: dict) -> dict:
+    if not champion:
+        return {}
+    champion_name = champion.get('name') or champion.get('id', '')
+    override = overrides.get(_normalize_text(champion_name))
+    if isinstance(override, dict):
+        return {
+            'early': override.get('early', 'average'),
+            'mid': override.get('mid', 'average'),
+            'late': override.get('late', 'average'),
+            'notes': override.get('notes', ''),
+            'source': 'local_override',
+            'tags': champion.get('tags', []),
+        }
+
+    early, mid, late = 1, 1, 1
+    tags = set(champion.get('tags', []))
+    if 'Marksman' in tags:
+        early -= 1
+        late += 1
+    if 'Assassin' in tags:
+        early += 1
+        late -= 1
+    if 'Mage' in tags:
+        late += 1
+    if 'Tank' in tags:
+        early -= 1
+        mid += 1
+        late += 1
+    if 'Support' in tags:
+        early += 1
+        mid += 1
+    if 'Fighter' in tags:
+        early += 1
+        mid += 1
+
+    stats = champion.get('stats', {})
+    hp = stats.get('hp', 0.0)
+    hp_growth = stats.get('hpperlevel', 0.0)
+    ad = stats.get('attackdamage', 0.0)
+    ad_growth = stats.get('attackdamageperlevel', 0.0)
+    armor = stats.get('armor', 0.0)
+    armor_growth = stats.get('armorperlevel', 0.0)
+    mr = stats.get('spellblock', 0.0)
+    mr_growth = stats.get('spellblockperlevel', 0.0)
+    base_power = hp + (ad * 1.5) + ((armor + mr) * 8)
+    late_power = (hp + hp_growth * 18) + ((ad + ad_growth * 18) * 1.5) + ((armor + armor_growth * 18 + mr + mr_growth * 18) * 8)
+    growth_ratio = _safe_ratio(late_power, max(base_power, 1))
+    if growth_ratio >= 2.2:
+        early -= 1
+        late += 1
+    elif growth_ratio <= 1.8:
+        early += 1
+        late -= 1
+
+    return {
+        'early': _phase_label(_clamp(early, 0, 2)),
+        'mid': _phase_label(_clamp(mid, 0, 2)),
+        'late': _phase_label(_clamp(late, 0, 2)),
+        'notes': f"Heuristic profile from champion tags ({', '.join(sorted(tags))}) and stat growth.",
+        'source': 'heuristic',
+        'tags': sorted(tags),
+    }
+
+
+def _fetch_rank_entries(platform_region: str, summoner_id: str) -> list[dict]:
+    if not _external_knowledge_enabled():
+        return []
+    if not platform_region or not summoner_id:
+        return []
+    if not current_app.config.get('RIOT_API_KEY'):
+        return []
+
+    key = (platform_region, summoner_id)
+    now = time.time()
+    with _CACHE_LOCK:
+        cached = _RANK_CACHE.get(key)
+        if cached and cached['expires_at'] > now:
+            return cached['entries']
+
+    entries: list[dict] = []
+    try:
+        watcher = get_watcher()
+        response = watcher.league.by_summoner(platform_region, summoner_id)
+        if isinstance(response, list):
+            entries = response
+    except (ValueError, ApiError, Exception):
+        entries = []
+
+    with _CACHE_LOCK:
+        _RANK_CACHE[key] = {'expires_at': now + 1800, 'entries': entries}
+    return entries
+
+
+def _build_rank_context(analysis: dict, participants: list[dict], duration_minutes: float) -> dict:
+    context = {'available': False}
+    rank_queue = _rank_queue_for_analysis(analysis)
+    if not rank_queue:
+        context['message'] = 'Non-ranked queue: rank benchmark skipped.'
+        return context
+
+    platform_region = analysis.get('platform_region', '')
+    if not platform_region:
+        context['message'] = 'Missing platform region for rank lookup.'
+        return context
+
+    player, _, _ = _find_player_and_teams(participants)
+    player_summoner_id = analysis.get('player_summoner_id') or (player or {}).get('summoner_id', '')
+    if not player_summoner_id:
+        context['message'] = 'Missing summoner ID for rank lookup.'
+        return context
+
+    player_rank = _choose_rank_entry(_fetch_rank_entries(platform_region, player_summoner_id), rank_queue)
+    if not player_rank:
+        context['message'] = 'Player rank not available from Riot League API.'
+        return context
+
+    rank_by_summoner: dict[str, dict] = {}
+    for participant in participants:
+        sid = participant.get('summoner_id', '')
+        if not sid:
+            continue
+        entry = _choose_rank_entry(_fetch_rank_entries(platform_region, sid), rank_queue)
+        if entry:
+            rank_by_summoner[sid] = entry
+
+    tier_counts = {}
+    rank_scores = []
+    for entry in rank_by_summoner.values():
+        tier = entry.get('tier', 'UNRANKED')
+        tier_counts[tier] = tier_counts.get(tier, 0) + 1
+        rank_scores.append(_rank_score(entry))
+
+    player_score = _rank_score(player_rank)
+    nearby_peers = []
+    for participant in participants:
+        sid = participant.get('summoner_id', '')
+        entry = rank_by_summoner.get(sid)
+        if entry and abs(_rank_score(entry) - player_score) <= 120:
+            nearby_peers.append(participant)
+
+    benchmark_lines = []
+    if player and len(nearby_peers) >= 2:
+        peer_metrics = [_participant_metrics(p, duration_minutes) for p in nearby_peers]
+        player_metrics = _participant_metrics(player, duration_minutes)
+        benchmark_lines = [
+            _describe_delta(player_metrics['gpm'], _median_metric(peer_metrics, 'gpm'), 'Gold/min vs similar-rank lobby', '/min'),
+            _describe_delta(player_metrics['dpm'], _median_metric(peer_metrics, 'dpm'), 'Damage/min vs similar-rank lobby', '/min'),
+            _describe_delta(player_metrics['cspm'], _median_metric(peer_metrics, 'cspm'), 'CS/min vs similar-rank lobby', '/min'),
+            _describe_delta(player_metrics['vpm'], _median_metric(peer_metrics, 'vpm'), 'Vision/min vs similar-rank lobby', '/min'),
+        ]
+
+    score_min = min(rank_scores) if rank_scores else None
+    score_max = max(rank_scores) if rank_scores else None
+    context.update({
+        'available': True,
+        'queue': rank_queue,
+        'player_rank': _format_rank_entry(player_rank),
+        'sample_size': len(rank_by_summoner),
+        'tier_distribution': tier_counts,
+        'rank_spread': [round(score_min, 2), round(score_max, 2)] if score_min is not None and score_max is not None else [],
+        'nearby_peer_count': len(nearby_peers),
+        'benchmarks': [line for line in benchmark_lines if line],
+    })
+    return context
+
+
+def _build_item_context(analysis: dict, player: dict | None, item_lookup: dict) -> dict:
+    item_ids = analysis.get('item_ids') or (player or {}).get('item_ids') or []
+    if not item_ids:
+        return {'items': [], 'tags': {}}
+
+    items = []
+    tag_counts: dict[str, int] = {}
+    for item_id in item_ids:
+        item_data = item_lookup.get(item_id, {})
+        item_name = item_data.get('name', f'Item {item_id}')
+        tags = item_data.get('tags', [])
+        for tag in tags:
+            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+        items.append({
+            'id': item_id,
+            'name': item_name,
+            'tags': tags,
+            'description': _strip_html(item_data.get('description', '')),
+        })
+    return {'items': items, 'tags': tag_counts}
+
+
+def _team_summary(team: list[dict], champion_lookup: dict, phase_overrides: dict) -> dict:
+    tag_counts: dict[str, int] = {}
+    phase_counts = {'early': 0, 'mid': 0, 'late': 0}
+    for participant in team:
+        champion_name = participant.get('champion', '')
+        champ_data = _resolve_champion(champion_name, champion_lookup)
+        profile = _champion_phase_profile(champ_data, phase_overrides) if champ_data else {}
+        for tag in profile.get('tags', []):
+            tag_counts[tag] = tag_counts.get(tag, 0) + 1
+        if profile.get('early') == 'strong':
+            phase_counts['early'] += 1
+        if profile.get('mid') == 'strong':
+            phase_counts['mid'] += 1
+        if profile.get('late') == 'strong':
+            phase_counts['late'] += 1
+
+    notes = []
+    frontline = tag_counts.get('Tank', 0) + tag_counts.get('Fighter', 0)
+    backline = tag_counts.get('Mage', 0) + tag_counts.get('Marksman', 0)
+    if frontline <= 1:
+        notes.append('Limited frontline durability.')
+    if frontline >= 2 and backline >= 2:
+        notes.append('Balanced front-to-back teamfight structure.')
+    physical = tag_counts.get('Marksman', 0) + tag_counts.get('Assassin', 0) + tag_counts.get('Fighter', 0)
+    magic = tag_counts.get('Mage', 0) + tag_counts.get('Support', 0)
+    if physical >= 4:
+        notes.append('Damage profile skews physical; armor stacking is a risk.')
+    if magic >= 4:
+        notes.append('Damage profile skews magic; MR stacking is a risk.')
+    strongest_phase = max(phase_counts, key=phase_counts.get) if team else ''
+    if strongest_phase:
+        notes.append(f'Power spike bias: {strongest_phase} game.')
+    return {'tags': tag_counts, 'phase_counts': phase_counts, 'notes': notes}
+
+
+def _build_synergy_notes(allies: list[dict], local_knowledge: dict) -> list[str]:
+    synergy_rules = local_knowledge.get('synergy_pairs', [])
+    if not isinstance(synergy_rules, list):
+        return []
+    ally_set = {_normalize_text(p.get('champion', '')) for p in allies}
+    notes = []
+    for rule in synergy_rules:
+        if not isinstance(rule, dict):
+            continue
+        champs = rule.get('champions', [])
+        if not isinstance(champs, list) or len(champs) < 2:
+            continue
+        needed = {_normalize_text(name) for name in champs}
+        if needed.issubset(ally_set):
+            reason = rule.get('reason', 'Strong interaction pattern.')
+            notes.append(f"{'/'.join(champs)}: {reason}")
+    return notes
+
+
+def _build_team_comp_context(participants: list[dict], champion_lookup: dict, local_knowledge: dict) -> dict:
+    player, allies, enemies = _find_player_and_teams(participants)
+    if not player:
+        return {}
+    phase_overrides = local_knowledge.get('champion_phase_overrides', {})
+    if not isinstance(phase_overrides, dict):
+        phase_overrides = {}
+    return {
+        'ally': _team_summary(allies, champion_lookup, phase_overrides),
+        'enemy': _team_summary(enemies, champion_lookup, phase_overrides),
+        'synergy_notes': _build_synergy_notes(allies, local_knowledge),
+    }
+
+
+def _build_relative_performance_context(analysis: dict, participants: list[dict], duration_minutes: float) -> dict:
+    player, allies, _ = _find_player_and_teams(participants)
+    if not player:
+        return {}
+    lobby_metrics = [_participant_metrics(p, duration_minutes) for p in participants]
+    player_metrics = _participant_metrics(player, duration_minutes)
+    lines = [
+        _describe_delta(player_metrics['gpm'], _median_metric(lobby_metrics, 'gpm'), 'Gold/min vs full lobby', '/min'),
+        _describe_delta(player_metrics['dpm'], _median_metric(lobby_metrics, 'dpm'), 'Damage/min vs full lobby', '/min'),
+        _describe_delta(player_metrics['cspm'], _median_metric(lobby_metrics, 'cspm'), 'CS/min vs full lobby', '/min'),
+        _describe_delta(player_metrics['vpm'], _median_metric(lobby_metrics, 'vpm'), 'Vision/min vs full lobby', '/min'),
+    ]
+    team_gold = sum(p.get('gold_earned', 0) for p in allies)
+    team_damage = sum(p.get('total_damage', 0) for p in allies)
+    if team_gold:
+        lines.append(f"Gold share on own team: {round(player.get('gold_earned', 0) * 100 / team_gold, 1)}%")
+    if team_damage:
+        lines.append(f"Damage share on own team: {round(player.get('total_damage', 0) * 100 / team_damage, 1)}%")
+    role_peers = []
+    position = player.get('position', '')
+    if position:
+        role_peers = [p for p in participants if p.get('position') == position and not p.get('is_player')]
+    if role_peers:
+        role_metrics = [_participant_metrics(p, duration_minutes) for p in role_peers]
+        lines.append(_describe_delta(player_metrics['dpm'], _median_metric(role_metrics, 'dpm'), f'Damage/min vs {_format_position(position)} counterpart', '/min'))
+        lines.append(_describe_delta(player_metrics['cspm'], _median_metric(role_metrics, 'cspm'), f'CS/min vs {_format_position(position)} counterpart', '/min'))
+
+    lane_opp = analysis.get('lane_opponent')
+    lane_text = ''
+    if lane_opp:
+        lane_kda = round(_safe_ratio(lane_opp.get('kills', 0) + lane_opp.get('assists', 0), max(1, lane_opp.get('deaths', 0))), 2)
+        lane_gold = round(_safe_ratio(lane_opp.get('gold_earned', 0), duration_minutes), 2)
+        lane_dpm = round(_safe_ratio(lane_opp.get('total_damage', 0), duration_minutes), 2)
+        lane_cspm = round(_safe_ratio(lane_opp.get('cs', 0), duration_minutes), 2)
+        lane_text = (
+            f"Lane matchup vs {lane_opp.get('champion', '?')}: "
+            f"KDA {player_metrics['kda']} vs {lane_kda}, "
+            f"GPM {player_metrics['gpm']} vs {lane_gold}, "
+            f"DPM {player_metrics['dpm']} vs {lane_dpm}, "
+            f"CSPM {player_metrics['cspm']} vs {lane_cspm}."
+        )
+    return {'lines': [line for line in lines if line], 'lane_matchup_line': lane_text}
+
+
+def _build_champion_context(analysis: dict, champion_lookup: dict, local_knowledge: dict) -> dict:
+    phase_overrides = local_knowledge.get('champion_phase_overrides', {})
+    if not isinstance(phase_overrides, dict):
+        phase_overrides = {}
+    player_champion = _resolve_champion(analysis.get('champion', ''), champion_lookup)
+    player_profile = _champion_phase_profile(player_champion, phase_overrides) if player_champion else {}
+    lane_profile = {}
+    lane_opponent = analysis.get('lane_opponent')
+    if lane_opponent:
+        lane_champion = _resolve_champion(lane_opponent.get('champion', ''), champion_lookup)
+        lane_profile = _champion_phase_profile(lane_champion, phase_overrides) if lane_champion else {}
+    return {'player_profile': player_profile, 'lane_profile': lane_profile}
+
+
+def _build_patch_context(local_knowledge: dict) -> dict:
+    patch = _fetch_current_patch()
+    patch_notes_map = local_knowledge.get('patch_notes', {})
+    if not isinstance(patch_notes_map, dict):
+        patch_notes_map = {}
+    notes = []
+    if patch:
+        notes.extend(patch_notes_map.get(patch, []))
+        patch_mm = '.'.join(patch.split('.')[:2])
+        if not notes and patch_mm:
+            notes.extend(patch_notes_map.get(patch_mm, []))
+        patch_major = patch.split('.')[0]
+        if not notes and patch_major:
+            notes.extend(patch_notes_map.get(patch_major, []))
+    default_notes = local_knowledge.get('default_patch_notes', [])
+    if not notes and isinstance(default_notes, list):
+        notes = default_notes
+    return {'current_patch': patch, 'notes': notes}
+
+
+def _build_match_timestamp_context(analysis: dict) -> str:
+    timestamp = analysis.get('game_start_timestamp')
+    if not timestamp:
+        return ''
+    try:
+        dt = datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
+        return dt.strftime('%Y-%m-%d %H:%M UTC')
+    except (TypeError, ValueError, OSError):
+        return ''
+
+
+def _build_knowledge_context(analysis: dict) -> dict:
+    participants = analysis.get('participants') or []
+    duration_minutes = max(float(analysis.get('game_duration', 0) or 0), 1.0)
+    local_knowledge = _load_local_knowledge()
+    patch_context = _build_patch_context(local_knowledge)
+    champion_lookup, item_lookup = _fetch_ddragon_data(patch_context.get('current_patch', ''))
+    player, _, _ = _find_player_and_teams(participants)
+    return {
+        'match_played_at': _build_match_timestamp_context(analysis),
+        'patch': patch_context,
+        'champions': _build_champion_context(analysis, champion_lookup, local_knowledge),
+        'items': _build_item_context(analysis, player, item_lookup),
+        'team_comp': _build_team_comp_context(participants, champion_lookup, local_knowledge),
+        'relative_performance': _build_relative_performance_context(analysis, participants, duration_minutes),
+        'rank': _build_rank_context(analysis, participants, duration_minutes),
+    }
+
+
+def _phase_summary(profile: dict) -> str:
+    if not profile:
+        return 'unknown'
+    note = profile.get('notes', '')
+    source = profile.get('source', '')
+    suffix = f" ({source})" if source else ''
+    if note:
+        suffix = f"{suffix}: {note}"
+    return f"early {profile.get('early', 'average')}, mid {profile.get('mid', 'average')}, late {profile.get('late', 'average')}{suffix}"
+
+
+def _format_knowledge_context(context: dict) -> str:
+    lines = []
+    played_at = context.get('match_played_at', '')
+    if played_at:
+        lines.append(f"- Match start time: {played_at}")
+    patch = context.get('patch', {})
+    patch_version = patch.get('current_patch', '') or 'unknown'
+    lines.append(f"- Current Data Dragon patch: {patch_version}")
+    patch_notes = patch.get('notes', [])
+    if patch_notes:
+        lines.append(f"- Patch-specific notes: {' | '.join(patch_notes)}")
+    else:
+        lines.append('- Patch-specific notes: none loaded; do not invent exact buff/nerf details.')
+
+    champions = context.get('champions', {})
+    lines.append(f"- Player champion phase profile: {_phase_summary(champions.get('player_profile', {}))}")
+    lane_profile = champions.get('lane_profile', {})
+    if lane_profile:
+        lines.append(f"- Lane opponent phase profile: {_phase_summary(lane_profile)}")
+
+    items = context.get('items', {})
+    item_names = [item.get('name', f"Item {item.get('id', '?')}") for item in items.get('items', [])]
+    if item_names:
+        lines.append(f"- Final build items: {', '.join(item_names)}")
+    item_tags = items.get('tags', {})
+    if item_tags:
+        tag_summary = ', '.join(f"{tag}:{count}" for tag, count in sorted(item_tags.items()))
+        lines.append(f"- Item tag mix: {tag_summary}")
+
+    team_comp = context.get('team_comp', {})
+    ally_notes = (team_comp.get('ally') or {}).get('notes', [])
+    enemy_notes = (team_comp.get('enemy') or {}).get('notes', [])
+    if ally_notes:
+        lines.append(f"- Ally comp profile: {' | '.join(ally_notes)}")
+    if enemy_notes:
+        lines.append(f"- Enemy comp profile: {' | '.join(enemy_notes)}")
+    synergy_notes = team_comp.get('synergy_notes', [])
+    if synergy_notes:
+        lines.append(f"- Ally synergy patterns: {' | '.join(synergy_notes)}")
+
+    rank = context.get('rank', {})
+    if rank.get('available'):
+        lines.append(f"- Player rank ({rank.get('queue', '')}): {rank.get('player_rank', 'Unknown')}")
+        lines.append(f"- Ranked sample size in this lobby: {rank.get('sample_size', 0)}")
+        tier_distribution = rank.get('tier_distribution', {})
+        if tier_distribution:
+            dist_text = ', '.join(f"{tier}:{count}" for tier, count in sorted(tier_distribution.items()))
+            lines.append(f"- Lobby tier distribution: {dist_text}")
+        for line in rank.get('benchmarks', []):
+            lines.append(f"- {line}")
+    else:
+        lines.append(f"- Rank context: {rank.get('message', 'Unavailable')}")
+
+    relative = context.get('relative_performance', {})
+    for line in relative.get('lines', []):
+        lines.append(f"- {line}")
+    lane_line = relative.get('lane_matchup_line', '')
+    if lane_line:
+        lines.append(f"- {lane_line}")
+    return '\n'.join(lines)
+
+
 def _build_prompt(analysis: dict) -> tuple[str, str]:
     """Build the system and user prompts for LLM analysis."""
-    result_str = "Victory" if analysis['win'] else "Defeat"
-    system = "You are a concise, expert League of Legends performance coach. Give specific, data-driven advice."
+    result_str = 'Victory' if analysis['win'] else 'Defeat'
+    system = (
+        'You are a concise, expert League of Legends coach. '
+        'Use provided match data and knowledge context to produce specific, evidence-based advice. '
+        'If a knowledge field is unavailable, say so briefly instead of guessing.'
+    )
 
     position = analysis.get('player_position', '')
-    position_line = f"- Position: {_format_position(position)}\n" if position else ""
-
-    # Lane opponent section
-    opponent_section = ""
+    position_line = f"- Position: {_format_position(position)}\n" if position else ''
+    opponent_section = ''
     lane_opp = analysis.get('lane_opponent')
     if lane_opp:
         opp_kda = f"{lane_opp.get('kills', 0)}/{lane_opp.get('deaths', 0)}/{lane_opp.get('assists', 0)}"
@@ -35,8 +716,7 @@ def _build_prompt(analysis: dict) -> tuple[str, str]:
             f"- Vision Score: {lane_opp.get('vision_score', '?')}\n"
         )
 
-    # Team composition sections
-    team_section = ""
+    team_section = ''
     participants = analysis.get('participants')
     if participants:
         player_team = None
@@ -60,17 +740,24 @@ def _build_prompt(analysis: dict) -> tuple[str, str]:
                 )
                 team_section += f"Enemy Team: {enemy_str}\n"
 
-    matchup_instruction = ""
+    knowledge_context = {}
+    try:
+        knowledge_context = _build_knowledge_context(analysis)
+    except Exception:
+        logger.exception('Knowledge context build failed; continuing with base metrics prompt.')
+    knowledge_section = _format_knowledge_context(knowledge_context) if knowledge_context else '- Knowledge context unavailable.'
+
+    matchup_instruction = ''
     if lane_opp:
-        matchup_instruction = "2. Lane matchup performance — how did you do vs your direct opponent?\n"
+        matchup_instruction = '2. Lane matchup performance and matchup dynamics across game phases\n'
 
     user = (
-        "You are an expert League of Legends coach. Analyze this match performance "
-        "and provide specific, actionable coaching advice.\n\n"
+        "Analyze this League of Legends match and provide focused coaching advice.\n\n"
         "Match Data:\n"
         f"- Champion: {analysis['champion']}\n"
         f"{position_line}"
         f"- Result: {result_str}\n"
+        f"- Queue: {analysis.get('queue_type', 'Unknown')}\n"
         f"- KDA: {analysis['kills']}/{analysis['deaths']}/{analysis['assists']} (Ratio: {analysis['kda']})\n"
         f"- Gold: {analysis['gold_earned']} total ({analysis['gold_per_min']}/min)\n"
         f"- Damage: {analysis['total_damage']} total ({analysis['damage_per_min']}/min)\n"
@@ -79,48 +766,39 @@ def _build_prompt(analysis: dict) -> tuple[str, str]:
         f"- Game Duration: {analysis['game_duration']} minutes\n"
         f"{opponent_section}"
         f"{team_section}\n"
-        "Provide a concise analysis (3-5 paragraphs) covering:\n"
-        "1. Overall performance assessment for this champion\n"
+        "Knowledge Context:\n"
+        f"{knowledge_section}\n\n"
+        "Provide a concise analysis (3-5 short paragraphs) covering:\n"
+        "1. Overall performance in this match relative to role/champion expectations\n"
         f"{matchup_instruction}"
-        f"{'3' if lane_opp else '2'}. Key strengths shown in this match\n"
-        f"{'4' if lane_opp else '3'}. Specific areas to improve with actionable advice\n"
-        f"{'5' if lane_opp else '4'}. One concrete thing to practice in the next game\n\n"
-        "Keep it direct and specific to this match data. No generic advice."
+        f"{'3' if lane_opp else '2'}. How itemization, rank context, and team compositions shaped this game\n"
+        f"{'4' if lane_opp else '3'}. Key strengths shown in this match\n"
+        f"{'5' if lane_opp else '4'}. Specific, actionable improvements for next games\n"
+        f"{'6' if lane_opp else '5'}. One concrete practice focus for the next game\n\n"
+        "Keep it direct and specific to this data. Avoid generic filler."
     )
     return system, user
 
 
 def get_llm_analysis(analysis: dict) -> str | None:
-    """Generate deep AI analysis for a match using the LLM API.
-
-    Uses the OpenCode Zen API (OpenAI-compatible chat completions endpoint).
-    Returns the analysis text on success, None on failure.
-    Errors are logged but not surfaced. Use get_llm_analysis_detailed
-    for admin/debug use cases that need error details.
-    """
+    """Generate deep AI analysis for a match using the LLM API."""
     result, error = get_llm_analysis_detailed(analysis)
     if error:
-        logger.error("LLM analysis failed: %s", error)
+        logger.error('LLM analysis failed: %s', error)
     return result
 
 
 def get_llm_analysis_detailed(analysis: dict) -> tuple[str | None, str | None]:
-    """Generate LLM analysis and return (result, error_message).
-
-    On success: (analysis_text, None)
-    On failure: (None, error_description)
-    """
+    """Generate LLM analysis and return (result, error_message)."""
     api_key = current_app.config.get('LLM_API_KEY', '')
     api_url = current_app.config.get('LLM_API_URL', '')
     model = current_app.config.get('LLM_MODEL', 'deepseek-chat')
-
     if not api_key:
-        return None, "LLM_API_KEY is not set."
+        return None, 'LLM_API_KEY is not set.'
     if not api_url:
-        return None, "LLM_API_URL is not set."
+        return None, 'LLM_API_URL is not set.'
 
     system_prompt, user_prompt = _build_prompt(analysis)
-
     try:
         resp = requests.post(
             api_url,
@@ -139,7 +817,6 @@ def get_llm_analysis_detailed(analysis: dict) -> tuple[str | None, str | None]:
             },
             timeout=90,
         )
-
         if resp.status_code == 401:
             return None, f"Authentication failed (401). Check your LLM_API_KEY. Response: {resp.text[:200]}"
         if resp.status_code == 404:
@@ -150,19 +827,15 @@ def get_llm_analysis_detailed(analysis: dict) -> tuple[str | None, str | None]:
         raw_body = resp.text
         if not raw_body or not raw_body.strip():
             return None, f"LLM API returned empty response body. URL: {api_url} | Model: {model}"
-
         try:
             data = resp.json()
         except ValueError:
             return None, f"LLM API returned non-JSON response. URL: {api_url} | Body: {raw_body[:300]}"
-
         message = data.get('choices', [{}])[0].get('message', {})
         content = message.get('content') or message.get('reasoning_content') or ''
         if not content:
             return None, f"LLM API response missing choices/content. URL: {api_url} | Body: {raw_body[:300]}"
-
         return content.strip(), None
-
     except requests.Timeout:
         return None, f"Request timed out after 90s. URL: {api_url}"
     except requests.RequestException as e:

--- a/app/config.py
+++ b/app/config.py
@@ -11,6 +11,12 @@ def _fix_db_url(url):
     return url
 
 
+def _to_bool(value: str, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return str(value).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
 class Config:
     SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key-change-in-production')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
@@ -33,6 +39,8 @@ class Config:
     LLM_API_KEY = os.environ.get('LLM_API_KEY', '')
     LLM_API_URL = os.environ.get('LLM_API_URL', '')
     LLM_MODEL = os.environ.get('LLM_MODEL', 'deepseek-chat')
+    LLM_KNOWLEDGE_EXTERNAL = _to_bool(os.environ.get('LLM_KNOWLEDGE_EXTERNAL'), True)
+    LLM_KNOWLEDGE_FILE = os.environ.get('LLM_KNOWLEDGE_FILE', '')
 
 
 class DevelopmentConfig(Config):

--- a/app/dashboard/routes.py
+++ b/app/dashboard/routes.py
@@ -208,6 +208,7 @@ def api_matches():
 def api_ai_analysis(match_db_id):
     """Run or return cached AI analysis for a match."""
     match = MatchAnalysis.query.filter_by(id=match_db_id, user_id=current_user.id).first_or_404()
+    riot_account = RiotAccount.query.filter_by(user_id=current_user.id).first()
 
     if match.llm_analysis:
         return jsonify({'analysis': match.llm_analysis, 'cached': True})
@@ -216,6 +217,7 @@ def api_ai_analysis(match_db_id):
     player_position, lane_opponent = derive_lane_context(participants)
 
     analysis_dict = {
+        'match_id': match.match_id,
         'champion': match.champion,
         'win': match.win,
         'kills': match.kills,
@@ -229,9 +231,12 @@ def api_ai_analysis(match_db_id):
         'vision_score': match.vision_score,
         'cs_total': match.cs_total,
         'game_duration': match.game_duration,
+        'queue_type': match.queue_type,
         'player_position': player_position,
         'lane_opponent': lane_opponent,
         'participants': participants,
+        'platform_region': riot_account.region if riot_account else '',
+        'player_puuid': riot_account.puuid if riot_account else '',
     }
 
     result, error = get_llm_analysis_detailed(analysis_dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def app():
         LLM_API_KEY="test-llm-key",
         LLM_API_URL="https://api.example.com/v1/chat/completions",
         LLM_MODEL="test-model",
+        LLM_KNOWLEDGE_EXTERNAL=False,
     )
     with app.app_context():
         _db.create_all()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -124,6 +124,9 @@ class TestAnalyzeMatch:
         assert result["player_position"] == "MIDDLE"
         assert result["lane_opponent"] is not None
         assert result["lane_opponent"]["champion"] == "Syndra"
+        assert "item_ids" in result
+        assert "player_summoner_id" in result
+        assert result["queue_id"] == 420
 
     def test_player_not_found_in_match(self):
         watcher = MagicMock()
@@ -214,6 +217,8 @@ class TestAnalyzeMatch:
         assert player_entries[0]["summoner_name"] == "TestPlayer"
         assert player_entries[0]["tagline"] == "NA1"
         assert player_entries[0]["team_id"] == 100
+        assert "summoner_id" in player_entries[0]
+        assert "item_ids" in player_entries[0]
 
         assert player_entries[0]["position"] == "MIDDLE"
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -94,6 +94,7 @@ class TestGetLlmAnalysis:
         assert "Ahri" in user_message
         assert "8/3/12" in user_message
         assert "Victory" in user_message
+        assert "Knowledge Context" in user_message
 
     @patch("app.analysis.llm.requests.post")
     def test_loss_result_in_prompt(self, mock_post, app):
@@ -111,6 +112,7 @@ class TestGetLlmAnalysis:
         call_kwargs = mock_post.call_args
         user_message = call_kwargs[1]["json"]["messages"][1]["content"]
         assert "Defeat" in user_message
+        assert "Current Data Dragon patch" in user_message
 
 
 class TestGetLlmAnalysisDetailed:

--- a/worker/jobs.py
+++ b/worker/jobs.py
@@ -53,6 +53,7 @@ def check_all_users_matches(app):
                     analysis = analyze_match(watcher, routing, riot_account.puuid, match_id)
                     if not analysis:
                         continue
+                    analysis['platform_region'] = riot_account.region
 
                     # Run LLM analysis
                     llm_text = None


### PR DESCRIPTION
## Summary
- replace single prompt-only LLM flow with a knowledge-enriched analysis context
- add rank-relative benchmarking, champion phase heuristics, team-comp/synergy context, item context, and patch-aware context
- pass required Riot metadata (platform region, summoner IDs, item IDs, queue metadata) through analysis pipeline
- add local editable knowledge pack at pp/analysis/knowledge/game_knowledge.json
- add config/env knobs for external knowledge fetches and knowledge file path
- update tests for new context fields and prompt structure

## Validation
- pytest -q (72 passed)
