### PR TITLE
Fix AI analysis truncation and markdown rendering issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ LLM_TIMEOUT_SECONDS=30
 LLM_RETRIES=1
 LLM_RETRY_BACKOFF_SECONDS=1.5
 LLM_MAX_TOKENS=2048
-# Optional stricter output cap (0 disables; example: 300)
+# Optional soft output target for prompt guidance (0 disables; example: 300)
 LLM_RESPONSE_TOKEN_TARGET=300
 LLM_KNOWLEDGE_EXTERNAL=1
 # Optional absolute or repo-relative path to custom LoL knowledge JSON

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ lol-analyzer/
 | `LLM_RETRIES` | Retries for timeout/5xx failures | `1` |
 | `LLM_RETRY_BACKOFF_SECONDS` | Base exponential retry backoff | `1.5` |
 | `LLM_MAX_TOKENS` | Max completion tokens for AI analysis | `2048` |
-| `LLM_RESPONSE_TOKEN_TARGET` | Optional stricter response token budget (`0` disables) | `0` |
+| `LLM_RESPONSE_TOKEN_TARGET` | Optional soft response token target for prompt guidance (`0` disables) | `0` |
 | `CHECK_INTERVAL_MINUTES` | How often to check for new matches | `5` |
 | `WEEKLY_SUMMARY_DAY` | Day of week for summary | `Monday` |
 | `WEEKLY_SUMMARY_TIME` | Time for summary (HH:MM) | `09:00` |

--- a/app/templates/dashboard/match_detail.html
+++ b/app/templates/dashboard/match_detail.html
@@ -324,41 +324,26 @@ document.addEventListener('DOMContentLoaded', function () {
         return div.innerHTML;
     }
 
-    function formatAiHtml(text) {
-        var lines = String(text || '').replace(/\r\n/g, '\n').split('\n');
-        var html = '<div class="ai-rich">';
-        var inList = false;
-        function closeList() {
-            if (inList) {
-                html += '</ul>';
-                inList = false;
-            }
-        }
-        lines.forEach(function (raw) {
-            var line = raw.trim();
-            if (!line) {
-                closeList();
-                return;
-            }
-            if (/^\d+\.\s+/.test(line)) {
-                closeList();
-                html += '<div class="ai-section-title">' + escapeHtml(line.replace(/^\d+\.\s+/, '')) + '</div>';
-                return;
-            }
-            if (/^[-*]\s+/.test(line)) {
-                if (!inList) {
-                    html += '<ul class="ai-list">';
-                    inList = true;
-                }
-                html += '<li>' + escapeHtml(line.replace(/^[-*]\s+/, '')) + '</li>';
-                return;
-            }
-            closeList();
-            html += '<p class="ai-paragraph">' + escapeHtml(line) + '</p>';
-        });
-        closeList();
-        html += '</div>';
-        return html;
+    function normalizeAiText(text) {
+        var normalized = String(text || '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+        normalized = normalized.replace(/^\s{0,3}#{1,6}\s*/gm, '');
+        normalized = normalized.replace(/^\s*>\s?/gm, '');
+        normalized = normalized.replace(/^\s*[-*+]\s+/gm, '');
+        normalized = normalized.replace(/^\s*\d+[.)]\s+/gm, '');
+        normalized = normalized.replace(/\*\*(.*?)\*\*/g, '$1');
+        normalized = normalized.replace(/__(.*?)__/g, '$1');
+        normalized = normalized.replace(/`([^`]+)`/g, '$1');
+        normalized = normalized.replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, '$1');
+        normalized = normalized.replace(/\n{3,}/g, '\n\n');
+        return normalized.trim();
+    }
+
+    function renderAiText(container, text) {
+        container.innerHTML = '';
+        var node = document.createElement('div');
+        node.className = 'llm-analysis';
+        node.textContent = normalizeAiText(text);
+        container.appendChild(node);
     }
 
     if (tabs) {
@@ -399,7 +384,7 @@ document.addEventListener('DOMContentLoaded', function () {
             initialText = '';
         }
         if (initialText) {
-            aiContent.innerHTML = '<div class="llm-analysis">' + formatAiHtml(initialText) + '</div>';
+            renderAiText(aiContent, initialText);
             aiBtn.classList.add('has-analysis');
             aiBtn.textContent = 'Regenerate AI Analysis';
         }
@@ -426,9 +411,12 @@ document.addEventListener('DOMContentLoaded', function () {
                         aiBtn.textContent = 'Run AI Analysis';
                         return;
                     }
-                    aiContent.innerHTML = '<div class="llm-analysis">' + formatAiHtml(data.analysis || '') + '</div>';
+                    renderAiText(aiContent, data.analysis || '');
                     if (data.stale && data.error) {
-                        aiContent.innerHTML += '<p class="card-muted">Using cached analysis because regeneration failed: ' + escapeHtml(data.error) + '</p>';
+                        var staleNode = document.createElement('p');
+                        staleNode.className = 'card-muted';
+                        staleNode.textContent = 'Using cached analysis because regeneration failed: ' + (data.error || '');
+                        aiContent.appendChild(staleNode);
                     }
                     aiBtn.disabled = false;
                     aiBtn.classList.add('has-analysis');


### PR DESCRIPTION
## Summary
- treat `LLM_RESPONSE_TOKEN_TARGET` as a soft prompt target instead of hard-capping completion tokens
- add plain-text output guidance and normalize markdown-ish model output in backend
- render AI analysis as plain text in dashboard UI (details page + match list)
- update tests to cover soft length targeting and markdown-to-plain-text normalization

## Why
Current behavior can truncate analysis by forcing `max_tokens` down to the target. This change keeps completion limits independent while giving the model a length target, and prevents markdown formatting issues in the UI.

## Validation
- `pytest -q tests/test_llm.py`
- `pytest -q tests/test_routes.py -k ai_analysis`