### PR TITLE
Use timezone-aware UTC timestamps in DB models and weekly jobs

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
 from app.extensions import db, login_manager
@@ -10,7 +10,7 @@ class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     email = db.Column(db.String(120), unique=True, nullable=False, index=True)
     password_hash = db.Column(db.String(256), nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    created_at = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     is_active_user = db.Column(db.Boolean, default=True)
 
     riot_accounts = db.relationship('RiotAccount', backref='user', lazy=True, cascade='all, delete-orphan')
@@ -79,7 +79,7 @@ class MatchAnalysis(db.Model):
     queue_type = db.Column(db.String(32), nullable=True)
     participants_json = db.Column(db.JSON, nullable=True)
     game_start_timestamp = db.Column(db.BigInteger, nullable=True)
-    analyzed_at = db.Column(db.DateTime, default=datetime.utcnow)
+    analyzed_at = db.Column(db.DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
 
 class WeeklySummary(db.Model):

--- a/worker/jobs.py
+++ b/worker/jobs.py
@@ -2,7 +2,7 @@
 
 import logging
 import time
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ def send_weekly_summaries(app):
         from app.analysis.engine import generate_weekly_summary
         from app.analysis.discord_notifier import send_message
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         today = now.strftime('%A')
 
         users = User.query.filter_by(is_active_user=True).all()


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` usage with timezone-aware UTC values
- store `User.created_at` and `MatchAnalysis.analyzed_at` as timezone-aware DateTime columns
- update weekly summary scheduler to use `datetime.now(timezone.utc)`

## Why
Python 3.12 deprecates naive UTC timestamp helpers and our test suite emitted warnings. This change removes warning sources and aligns timestamp handling with industry best practices.

## Validation
- `pytest -q`
- result: `118 passed`
