### PR TITLE
Add AI Coach Focus Plan to dashboard overview

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2254,13 +2254,68 @@ h4,
     backdrop-filter: blur(8px);
 }
 
+.coach-plan-card {
+    border: 1px solid var(--surface-outline);
+    background: linear-gradient(145deg, var(--surface-soft-overlay) 0%, var(--bg-panel) 100%);
+}
+
+.coach-score-badge {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+    background: var(--bg-chip-soft);
+    border: 1px solid var(--surface-outline);
+    border-radius: 12px;
+    padding: 8px 12px;
+    min-width: 92px;
+}
+
+.coach-score-badge span {
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-subtle);
+}
+
+.coach-score-badge strong {
+    font-size: 1.35rem;
+    line-height: 1;
+    color: var(--text);
+}
+
+.coach-plan-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px;
+}
+
+.coach-plan-grid h4 {
+    margin-bottom: 6px;
+}
+
+.coach-plan-grid ul {
+    margin: 0;
+    padding-left: 18px;
+    display: grid;
+    gap: 6px;
+}
+
+.coach-next-goal {
+    margin-top: 14px;
+    border-top: 1px dashed var(--surface-outline);
+    padding-top: 10px;
+    display: grid;
+    gap: 4px;
+}
+
 @media (max-width: 1200px) {
     .container { width: min(1080px, calc(100% - 40px)); }
     .features-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (max-width: 980px) {
-    .hero-shell, .workflow-track, .setup-check-grid, .admin-lookup-grid, .steps, .quick-guide-grid { grid-template-columns: 1fr; }
+    .hero-shell, .workflow-track, .setup-check-grid, .admin-lookup-grid, .steps, .quick-guide-grid, .coach-plan-grid { grid-template-columns: 1fr; }
     .metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .team-composition-dual, .composition-split { grid-template-columns: 1fr; }
     .match-box { grid-template-columns: 6px minmax(0, 1fr); }

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -52,6 +52,41 @@
         </div>
     </div>
 
+    <div class="card coach-plan-card">
+        <div class="section-head">
+            <div>
+                <div class="section-label">{{ lt('Differentiator', '核心差异化') }}</div>
+                <h3>{{ lt('AI Coach Focus Plan', 'AI 教练焦点计划') }}</h3>
+            </div>
+            <div class="coach-score-badge">
+                <span>{{ lt('Coach Score', '教练评分') }}</span>
+                <strong>{{ coach_plan.coach_score }}</strong>
+            </div>
+        </div>
+        <div class="coach-plan-grid">
+            <div>
+                <h4>{{ lt('Current Strengths', '当前优势') }}</h4>
+                <ul>
+                    {% for item in coach_plan.strengths %}
+                    <li>{{ item }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+            <div>
+                <h4>{{ lt('Priority Improvements', '优先提升项') }}</h4>
+                <ul>
+                    {% for item in coach_plan.focus_areas %}
+                    <li>{{ item }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+        <div class="coach-next-goal">
+            <strong>{{ lt('Actionable next-game goal:', '下局可执行目标：') }}</strong>
+            <span>{{ coach_plan.next_game_goal }}</span>
+        </div>
+    </div>
+
     <div class="card matches-card">
         <div class="section-head">
             <div>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -115,6 +115,12 @@ class TestDashboardAccess:
         resp = auth_client.get("/dashboard/")
         assert resp.status_code == 200
 
+    def test_dashboard_shows_ai_coach_focus_plan(self, auth_client):
+        resp = auth_client.get("/dashboard/")
+        assert resp.status_code == 200
+        assert b"AI Coach Focus Plan" in resp.data
+        assert b"Actionable next-game goal" in resp.data
+
     def test_settings_requires_login(self, client):
         resp = client.get("/dashboard/settings")
         assert resp.status_code in (302, 401)


### PR DESCRIPTION
## Summary
- add an **AI Coach Focus Plan** panel to dashboard overview
- generate deterministic personalized coaching signals from recent matches:
  - coach score (1-100)
  - top strengths
  - top priority improvement areas
  - one actionable next-game goal
- style the new panel for desktop/mobile responsiveness
- add route-level test coverage for coach panel visibility

## Product rationale
This pushes LoL Analyzer toward an AI-coach product experience (not just stat display), which is our intended differentiator vs metadata-only dashboards.

## Validation
- `pytest -q`
- result: `119 passed`

## Notes
- Live production UI check was performed on current Railway deployment to verify baseline UX and identify where this panel will improve onboarding clarity.
