### PR TITLE
Add Performance Trend Snapshot to AI coaching dashboard

### DIFF
--- a/app/dashboard/routes.py
+++ b/app/dashboard/routes.py
@@ -159,6 +159,63 @@ def _build_ai_coach_plan(matches: list[MatchAnalysis]) -> dict:
     }
 
 
+def _build_trend_snapshot(matches: list[MatchAnalysis]) -> dict:
+    """Compare recent window vs previous window to show trajectory."""
+    if not matches:
+        return {
+            'headline': lt('No trend yet', '暂无趋势数据'),
+            'signals': [lt('Complete more matches to unlock trend intelligence.', '完成更多对局后可解锁趋势洞察。')],
+        }
+
+    recent = matches[:5]
+    previous = matches[5:10]
+    if not previous:
+        return {
+            'headline': lt('Collecting baseline', '正在建立基线'),
+            'signals': [lt('Play 5 more matches to compare your trajectory.', '再完成 5 局后可对比成长轨迹。')],
+        }
+
+    def _avg(rows: list[MatchAnalysis], field: str) -> float:
+        vals = [getattr(r, field) or 0 for r in rows]
+        return sum(vals) / len(vals) if vals else 0.0
+
+    recent_win = sum(1 for r in recent if r.win) / len(recent)
+    prev_win = sum(1 for r in previous if r.win) / len(previous)
+
+    deltas = {
+        'win_rate': round((recent_win - prev_win) * 100, 1),
+        'kda': round(_avg(recent, 'kda') - _avg(previous, 'kda'), 2),
+        'gpm': round(_avg(recent, 'gold_per_min') - _avg(previous, 'gold_per_min'), 1),
+        'dpm': round(_avg(recent, 'damage_per_min') - _avg(previous, 'damage_per_min'), 1),
+    }
+
+    positives = sum(1 for value in deltas.values() if value > 0)
+    if positives >= 3:
+        headline = lt('You are trending up', '你正在上升期')
+    elif positives <= 1:
+        headline = lt('Stabilize fundamentals this week', '本周先稳住基本功')
+    else:
+        headline = lt('Mixed trend — refine execution', '趋势分化，建议精炼执行细节')
+
+    def _signal(label_en: str, label_zh: str, value: float, suffix: str = '') -> str:
+        arrow = '↑' if value > 0 else ('↓' if value < 0 else '→')
+        prefix = '+' if value > 0 else ''
+        text = f"{arrow} {lt(label_en, label_zh)} {prefix}{value}{suffix}"
+        return text
+
+    signals = [
+        _signal('Win rate delta', '胜率变化', deltas['win_rate'], '%'),
+        _signal('KDA delta', 'KDA 变化', deltas['kda']),
+        _signal('Gold/min delta', '每分钟经济变化', deltas['gpm']),
+        _signal('Damage/min delta', '每分钟伤害变化', deltas['dpm']),
+    ]
+
+    return {
+        'headline': headline,
+        'signals': signals,
+    }
+
+
 @dashboard_bp.route('/')
 @login_required
 def index():
@@ -186,6 +243,7 @@ def index():
 
     initial_matches = _serialize_matches(analyses)
     coach_plan = _build_ai_coach_plan(analyses)
+    trend_snapshot = _build_trend_snapshot(analyses)
 
     return render_template('dashboard/index.html',
         analyses=analyses,
@@ -195,6 +253,7 @@ def index():
         win_rate=win_rate,
         avg_kda=avg_kda,
         coach_plan=coach_plan,
+        trend_snapshot=trend_snapshot,
         riot_account=riot_account,
         discord_config=discord_config,
     )

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2309,6 +2309,23 @@ h4,
     gap: 4px;
 }
 
+.trend-snapshot-card {
+    border: 1px solid var(--surface-outline);
+    background: linear-gradient(145deg, var(--surface-soft-overlay) 0%, var(--bg-panel) 100%);
+}
+
+.trend-headline {
+    font-weight: 600;
+    margin-bottom: 10px;
+}
+
+.trend-signal-list {
+    margin: 0;
+    padding-left: 18px;
+    display: grid;
+    gap: 6px;
+}
+
 @media (max-width: 1200px) {
     .container { width: min(1080px, calc(100% - 40px)); }
     .features-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -87,6 +87,21 @@
         </div>
     </div>
 
+    <div class="card trend-snapshot-card">
+        <div class="section-head">
+            <div>
+                <div class="section-label">{{ lt('Progress Tracking', '进展追踪') }}</div>
+                <h3>{{ lt('Performance Trend Snapshot', '表现趋势快照') }}</h3>
+            </div>
+        </div>
+        <p class="trend-headline">{{ trend_snapshot.headline }}</p>
+        <ul class="trend-signal-list">
+            {% for signal in trend_snapshot.signals %}
+            <li>{{ signal }}</li>
+            {% endfor %}
+        </ul>
+    </div>
+
     <div class="card matches-card">
         <div class="section-head">
             <div>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -120,6 +120,7 @@ class TestDashboardAccess:
         assert resp.status_code == 200
         assert b"AI Coach Focus Plan" in resp.data
         assert b"Actionable next-game goal" in resp.data
+        assert b"Performance Trend Snapshot" in resp.data
 
     def test_settings_requires_login(self, client):
         resp = client.get("/dashboard/settings")


### PR DESCRIPTION
## Summary
- add a new **Performance Trend Snapshot** module on dashboard
- compare recent 5 matches vs previous 5 matches to generate trajectory deltas:
  - win rate delta
  - KDA delta
  - gold/min delta
  - damage/min delta
- generate a trend headline to guide user focus (uptrend / mixed / stabilize)
- keep language-aware UX for EN + ZH labels via existing i18n helpers

## Why this matters
This evolves the product from static match metadata into coaching intelligence over time. Users can see if they are actually improving, not just what happened in one game.

## Validation
- `pytest -q`
- result: `119 passed`
