### PR TITLE
docs: add pytest output example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,14 @@ Thank you for your interest in contributing to LoL Performance Analyzer! We welc
    ```
    - Keep PRs small and rerun checks locally before opening or updating a PR.
 
+   Expected output (example):
+   ```
+   ============================= test session starts =============================
+   collected XX items
+   ...
+   ====================== 137 passed
+   ```
+
 ## Code Style
 
 - Follow PEP 8 guidelines


### PR DESCRIPTION
Small contributor-doc improvement adding expected pytest output sample to avoid ambiguity while validating checks.