### PR TITLE
refactor: clarify AI coaching death focus wording

### DIFF
--- a/app/dashboard/routes.py
+++ b/app/dashboard/routes.py
@@ -140,7 +140,7 @@ def _build_ai_coach_plan(matches: list[MatchAnalysis]) -> dict:
     if win_rate < 50:
         focus_areas.append(lt('Prioritize cleaner mid-game decision making around objectives.', '优先提升中期围绕资源点的决策质量。'))
     if avg_kda < 2.8:
-        focus_areas.append(lt('Reduce avoidable deaths: target safer wave resets and exits.', '减少可避免死亡：优化推线后的回撤与转线时机。'))
+        focus_areas.append(lt('Reduce avoidable deaths: in extended skirmishes, disengage before overextending and keep deaths at 4 or fewer per game.', '减少可避免死亡：优化推线后的回撤与转线时机。'))
     if avg_gpm < 360:
         focus_areas.append(lt('Improve economy: maintain farm tempo between fights.', '提升经济效率：团战间隙维持补刀节奏。'))
     if avg_vision < 18:

--- a/tests/test_coach_plan.py
+++ b/tests/test_coach_plan.py
@@ -1,0 +1,39 @@
+from app.dashboard import routes as dashboard_routes
+from app.models import MatchAnalysis
+
+
+def test_ai_coach_plan_focus_area_uses_actionable_death_plan(monkeypatch):
+    """Low-KDA matches should emit an actionable death-focused recommendation."""
+
+    monkeypatch.setattr(dashboard_routes, "lt", lambda en, zh: en)
+
+    matches = [
+        MatchAnalysis(
+            win=False,
+            kda=2.1,
+            damage_per_min=600,
+            gold_per_min=300,
+            vision_score=10,
+            match_id="NA1_low_sample",
+        )
+    ]
+
+    plan = dashboard_routes._build_ai_coach_plan(matches)
+    focus_lines = " ".join(plan["focus_areas"])
+
+    assert "deaths at 4 or fewer per game" in focus_lines
+    assert "safer" not in focus_lines.lower()
+    assert any("Reduce avoidable deaths" in line for line in plan["focus_areas"])
+
+
+def test_ai_coach_plan_returns_no_plan_when_empty(monkeypatch):
+    """Empty match history should return a deterministic onboarding coaching plan."""
+
+    monkeypatch.setattr(dashboard_routes, "lt", lambda en, zh: en)
+
+    plan = dashboard_routes._build_ai_coach_plan([])
+
+    assert plan["coach_score"] == 0
+    assert plan["strengths"] == []
+    assert plan["focus_areas"] == []
+    assert "unlock" in plan["next_game_goal"]


### PR DESCRIPTION
## Summary
- Replace ambiguous coaching copy in deterministic coach plan with a concrete, actionable death-control recommendation.
- Add regression tests for coach plan behavior, including actionable text and empty history fallback.

## Testing
- python -m pytest tests/ -q