### PR TITLE
test: add autouse sqlalchemy session isolation fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,17 @@ def db(app):
         _db.session.commit()
 
 
+@pytest.fixture(autouse=True)
+def session_isolation(app):
+    """Reduce cross-test SQLAlchemy identity/session leakage."""
+    with app.app_context():
+        _db.session.expunge_all()
+    yield
+    with app.app_context():
+        _db.session.rollback()
+        _db.session.expunge_all()
+
+
 @pytest.fixture()
 def client(app, db):
     """A Flask test client."""


### PR DESCRIPTION
## Summary
- add an utouse test fixture to expunge SQLAlchemy identity-map state between tests
- perform rollback + expunge on teardown to reduce cross-test session leakage
- align with existing flaky-test note in test plan recommendation (expunge_all/session reset)

## Testing
- python -m pytest tests/