### PR TITLE
feat: add accessible semantics for dashboard queue filters

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -941,16 +941,50 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         if (filterBar) {
+            function setActiveQueueFilter(btn, focus) {
+                if (!btn) return;
+                filterBar.querySelectorAll('.filter-btn').forEach(function (b) {
+                    var isActive = b === btn;
+                    b.classList.toggle('active', isActive);
+                    b.setAttribute('aria-selected', isActive ? 'true' : 'false');
+                    b.tabIndex = isActive ? 0 : -1;
+                });
+                if (focus) {
+                    btn.focus();
+                }
+            }
+
             filterBar.addEventListener('click', function (e) {
                 var btn = e.target.closest('.filter-btn');
                 if (!btn) return;
-                filterBar.querySelectorAll('.filter-btn').forEach(function (b) {
-                    b.classList.remove('active');
-                    b.setAttribute('aria-pressed', 'false');
-                });
-                btn.classList.add('active');
-                btn.setAttribute('aria-pressed', 'true');
+                setActiveQueueFilter(btn, false);
                 filterByQueue(btn.getAttribute('data-queue'));
+            });
+
+            filterBar.addEventListener('keydown', function (e) {
+                var current = e.target.closest('.filter-btn');
+                if (!current) return;
+                var buttons = Array.prototype.slice.call(filterBar.querySelectorAll('.filter-btn'));
+                var currentIndex = buttons.indexOf(current);
+                if (currentIndex < 0) return;
+
+                var nextIndex = currentIndex;
+                if (e.key === 'ArrowRight') {
+                    nextIndex = (currentIndex + 1) % buttons.length;
+                } else if (e.key === 'ArrowLeft') {
+                    nextIndex = (currentIndex - 1 + buttons.length) % buttons.length;
+                } else if (e.key === 'Home') {
+                    nextIndex = 0;
+                } else if (e.key === 'End') {
+                    nextIndex = buttons.length - 1;
+                } else {
+                    return;
+                }
+
+                e.preventDefault();
+                var next = buttons[nextIndex];
+                setActiveQueueFilter(next, true);
+                filterByQueue(next.getAttribute('data-queue'));
             });
         }
 

--- a/app/templates/dashboard/index.html
+++ b/app/templates/dashboard/index.html
@@ -129,11 +129,11 @@
             <p class="card-muted">{{ lt('Stream AI coaching inline without leaving the dashboard.', '无需离开仪表盘即可实时查看 AI 建议。') }}</p>
         </div>
 
-        <div class="match-filter-bar" id="match-filter-bar" role="toolbar" aria-label="{{ lt('Filter matches by queue', '按队列筛选对局') }}">
-            <button type="button" class="filter-btn active" data-queue="" aria-pressed="true">{{ lt('All', '全部') }}</button>
-            <button type="button" class="filter-btn" data-queue="Ranked Solo" aria-pressed="false">{{ queue_label('Ranked Solo') }}</button>
-            <button type="button" class="filter-btn" data-queue="Ranked Flex" aria-pressed="false">{{ queue_label('Ranked Flex') }}</button>
-            <button type="button" class="filter-btn" data-queue="Normal Draft,Normal Blind" aria-pressed="false">{{ lt('Normal', '匹配') }}</button>
+        <div class="match-filter-bar" id="match-filter-bar" role="tablist" aria-label="{{ lt('Filter matches by queue', '按队列筛选对局') }}">
+            <button type="button" class="filter-btn active" id="queue-filter-all" data-queue="" role="tab" aria-selected="true" aria-controls="match-list" tabindex="0">{{ lt('All', '全部') }}</button>
+            <button type="button" class="filter-btn" id="queue-filter-ranked-solo" data-queue="Ranked Solo" role="tab" aria-selected="false" aria-controls="match-list" tabindex="-1">{{ queue_label('Ranked Solo') }}</button>
+            <button type="button" class="filter-btn" id="queue-filter-ranked-flex" data-queue="Ranked Flex" role="tab" aria-selected="false" aria-controls="match-list" tabindex="-1">{{ queue_label('Ranked Flex') }}</button>
+            <button type="button" class="filter-btn" id="queue-filter-normal" data-queue="Normal Draft,Normal Blind" role="tab" aria-selected="false" aria-controls="match-list" tabindex="-1">{{ lt('Normal', '匹配') }}</button>
         </div>
 
         <div id="match-list">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -152,10 +152,12 @@ class TestDashboardAccess:
         resp = auth_client.get("/dashboard/")
         assert resp.status_code == 200
         assert b'id="match-filter-bar"' in resp.data
-        assert b'role="toolbar"' in resp.data
+        assert b'role="tablist"' in resp.data
         assert b'aria-label="Filter matches by queue"' in resp.data
-        assert b'data-queue="" aria-pressed="true"' in resp.data
-        assert b'data-queue="Ranked Solo" aria-pressed="false"' in resp.data
+        assert b'id="queue-filter-all"' in resp.data
+        assert b'role="tab"' in resp.data
+        assert b'data-queue="" role="tab" aria-selected="true" aria-controls="match-list" tabindex="0"' in resp.data
+        assert b'data-queue="Ranked Solo" role="tab" aria-selected="false" aria-controls="match-list" tabindex="-1"' in resp.data
 
 
 class TestSyncRecentMatches:


### PR DESCRIPTION
## Summary
- upgrade dashboard queue filters to tab-style accessibility semantics (ole=tablist, ole=tab, ria-selected, ria-controls, 	abindex)
- keep selected-state styling behavior while syncing ARIA selection state in JS
- add keyboard navigation for queue filters (ArrowLeft/ArrowRight/Home/End) with immediate filtering
- add regression test asserting queue filter accessibility markup is rendered

## Testing
- python -m pytest tests/