### PR TITLE
Sanitize AI analysis errors for users and honor configured model values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,10 @@ DISCORD_CLIENT_ID=your-discord-client-id
 # LLM (OpenCode Zen API - OpenAI-compatible)
 LLM_API_KEY=your-zen-api-key
 LLM_API_URL=https://opencode.ai/zen/v1/chat/completions
-# Use a chat-completions model available on OpenCode Zen (examples: glm-4.7-free, kimi-k2.5-free, big-pickle)
-LLM_MODEL=glm-4.7-free
+# Set to a chat-completions model available on your provider account (example: glm-5)
+LLM_MODEL=glm-5
+# Optional comma-separated fallback models used only for retry variants (example: glm-4.5-air)
+LLM_FALLBACK_MODELS=
 LLM_TIMEOUT_SECONDS=30
 LLM_RETRIES=1
 LLM_RETRY_BACKOFF_SECONDS=1.5

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ lol-analyzer/
 | `RIOT_VERIFICATION_UUID` | Riot API verification UUID | (set in .env) |
 | `LLM_API_KEY` | LLM provider API key | (required for AI analysis) |
 | `LLM_API_URL` | OpenAI-compatible chat completions endpoint | (required for AI analysis) |
-| `LLM_MODEL` | Model name sent to provider | `deepseek-chat` |
+| `LLM_MODEL` | Model name sent to provider | (required for AI analysis) |
+| `LLM_FALLBACK_MODELS` | Optional comma-separated fallback model ids for retry variants | (optional) |
 | `LLM_TIMEOUT_SECONDS` | Timeout per LLM request attempt | `30` |
 | `LLM_RETRIES` | Retries for timeout/5xx failures | `1` |
 | `LLM_RETRY_BACKOFF_SECONDS` | Base exponential retry backoff | `1.5` |

--- a/app/analysis/llm_cache.py
+++ b/app/analysis/llm_cache.py
@@ -2,9 +2,6 @@
 
 from app.analysis import llm_prompt as _prompt
 
-_OPENCODE_ZEN_DEFAULT_CHAT_MODEL = _prompt._OPENCODE_ZEN_DEFAULT_CHAT_MODEL
-_OPENCODE_ZEN_CHAT_HINT_MODELS = _prompt._OPENCODE_ZEN_CHAT_HINT_MODELS
-
 
 def _is_opencode_zen_url(api_url: str) -> bool:
     return _prompt._is_opencode_zen_url(api_url)

--- a/app/analysis/llm_prompt.py
+++ b/app/analysis/llm_prompt.py
@@ -39,8 +39,6 @@ _DDRAGON_VERSIONS_URL = 'https://ddragon.leagueoflegends.com/api/versions.json'
 _DDRAGON_CHAMPIONS_URL = 'https://ddragon.leagueoflegends.com/cdn/{patch}/data/en_US/champion.json'
 _DDRAGON_ITEMS_URL = 'https://ddragon.leagueoflegends.com/cdn/{patch}/data/en_US/item.json'
 _OPENCODE_ZEN_MODELS_URL = 'https://opencode.ai/zen/v1/models'
-_OPENCODE_ZEN_DEFAULT_CHAT_MODEL = 'glm-4.7-free'
-_OPENCODE_ZEN_CHAT_HINT_MODELS = ('glm-4.7-free', 'kimi-k2.5-free', 'big-pickle')
 _LOCAL_KNOWLEDGE_DEFAULT = Path(__file__).with_name('knowledge').joinpath('game_knowledge.json')
 
 _CACHE_LOCK = threading.Lock()
@@ -100,6 +98,16 @@ def _fetch_opencode_zen_models() -> set[str]:
     return models
 
 
+def _configured_fallback_models() -> tuple[str, ...]:
+    raw = current_app.config.get('LLM_FALLBACK_MODELS', '') or ''
+    models: list[str] = []
+    for token in str(raw).split(','):
+        model = token.strip()
+        if model and model not in models:
+            models.append(model)
+    return tuple(models)
+
+
 def _resolve_provider_model(api_url: str, model: str) -> tuple[str | None, str | None]:
     """Validate/adapt model for provider endpoint quirks."""
     model = (model or '').strip()
@@ -116,26 +124,17 @@ def _resolve_provider_model(api_url: str, model: str) -> tuple[str | None, str |
             "Set LLM_API_URL to https://opencode.ai/zen/v1/chat/completions."
         )
 
-    if model == 'deepseek-chat':
-        logger.warning(
-            "LLM_MODEL=deepseek-chat is unavailable on OpenCode Zen. Falling back to %s.",
-            _OPENCODE_ZEN_DEFAULT_CHAT_MODEL,
-        )
-        model = _OPENCODE_ZEN_DEFAULT_CHAT_MODEL
-
-    if model.startswith(('gpt-', 'claude-', 'gemini-')):
-        hint = ', '.join(_OPENCODE_ZEN_CHAT_HINT_MODELS)
+    if model == 'deepseek-chat' or model.startswith(('gpt-', 'claude-', 'gemini-')):
         return None, (
             f"Model '{model}' on OpenCode Zen is not compatible with /chat/completions. "
-            f"Use a chat-completions model such as: {hint}."
+            f"Set LLM_MODEL to a model id listed by {_OPENCODE_ZEN_MODELS_URL}."
         )
 
     available_models = _fetch_opencode_zen_models()
     if available_models and model not in available_models:
-        hint = ', '.join(_OPENCODE_ZEN_CHAT_HINT_MODELS)
         return None, (
             f"LLM model '{model}' is not available on OpenCode Zen. "
-            f"Choose a model listed by {_OPENCODE_ZEN_MODELS_URL} (for example: {hint})."
+            f"Set LLM_MODEL to a model id listed by {_OPENCODE_ZEN_MODELS_URL}."
         )
     return model, None
 
@@ -1076,8 +1075,10 @@ def _request_body_variants(api_url: str, base_body: dict) -> list[dict]:
     minimal_current_model.pop('max_tokens', None)
     add_variant(minimal_current_model)
 
-    fallback_models = [_OPENCODE_ZEN_DEFAULT_CHAT_MODEL, *_OPENCODE_ZEN_CHAT_HINT_MODELS]
+    fallback_models = _configured_fallback_models()
     for fallback_model in fallback_models:
+        if fallback_model == minimal_current_model.get('model'):
+            continue
         fallback_variant = dict(minimal_current_model)
         fallback_variant['model'] = fallback_model
         add_variant(fallback_variant)
@@ -1089,7 +1090,7 @@ def _llm_request_settings() -> tuple[dict | None, str | None]:
     """Resolve validated provider settings shared by sync and stream calls."""
     api_key = current_app.config.get('LLM_API_KEY', '')
     api_url = current_app.config.get('LLM_API_URL', '')
-    model = current_app.config.get('LLM_MODEL', 'deepseek-chat')
+    model = current_app.config.get('LLM_MODEL', '')
     timeout_seconds = max(5, int(current_app.config.get('LLM_TIMEOUT_SECONDS', 30) or 30))
     retries = max(0, int(current_app.config.get('LLM_RETRIES', 1) or 1))
     retry_backoff = max(0.0, float(current_app.config.get('LLM_RETRY_BACKOFF_SECONDS', 1.5) or 1.5))

--- a/app/config.py
+++ b/app/config.py
@@ -43,7 +43,8 @@ class Config:
 
     LLM_API_KEY = os.environ.get('LLM_API_KEY', '')
     LLM_API_URL = os.environ.get('LLM_API_URL', '')
-    LLM_MODEL = os.environ.get('LLM_MODEL', 'deepseek-chat')
+    LLM_MODEL = os.environ.get('LLM_MODEL', '')
+    LLM_FALLBACK_MODELS = os.environ.get('LLM_FALLBACK_MODELS', '')
     LLM_TIMEOUT_SECONDS = int(os.environ.get('LLM_TIMEOUT_SECONDS', '30'))
     LLM_RETRIES = int(os.environ.get('LLM_RETRIES', '1'))
     LLM_RETRY_BACKOFF_SECONDS = float(os.environ.get('LLM_RETRY_BACKOFF_SECONDS', '1.5'))

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -592,7 +592,9 @@ class TestAiAnalysisRoute:
 
         assert resp.status_code == 504
         payload = resp.get_json()
-        assert "timed out" in payload["error"].lower()
+        assert payload["trace_id"]
+        assert "trace id" in payload["error"].lower()
+        assert "timed out" not in payload["error"].lower()
 
     def test_ai_analysis_timeout_returns_stale_cached_analysis(self, auth_client, db, user):
         match = MatchAnalysis(
@@ -633,7 +635,9 @@ class TestAiAnalysisRoute:
         assert payload["cached"] is True
         assert payload["stale"] is True
         assert payload["analysis"] == "existing cached analysis"
-        assert "timed out" in payload["error"].lower()
+        assert payload["trace_id"]
+        assert "trace id" in payload["error"].lower()
+        assert "timed out" not in payload["error"].lower()
 
     def test_ai_analysis_timeout_with_non_general_focus_returns_stale_cached_analysis(self, auth_client, db, user):
         match = MatchAnalysis(
@@ -678,7 +682,9 @@ class TestAiAnalysisRoute:
         assert payload["cached"] is True
         assert payload["stale"] is True
         assert payload["analysis"] == "existing cached analysis"
-        assert "timed out" in payload["error"].lower()
+        assert payload["trace_id"]
+        assert "trace id" in payload["error"].lower()
+        assert "timed out" not in payload["error"].lower()
 
     def test_ai_analysis_configuration_error_returns_400_without_cached_analysis(self, auth_client, db, user):
         match = MatchAnalysis(
@@ -716,7 +722,57 @@ class TestAiAnalysisRoute:
 
         assert resp.status_code == 400
         payload = resp.get_json()
-        assert "not compatible with /chat/completions" in payload["error"]
+        assert payload["trace_id"]
+        assert "trace id" in payload["error"].lower()
+        assert "not compatible with /chat/completions" not in payload["error"].lower()
+
+    def test_ai_analysis_configuration_error_is_visible_to_admin(self, client, db, app):
+        app.config["ADMIN_EMAIL"] = "admin@test.com"
+        admin = User(email="admin@test.com")
+        admin.set_password("adminpass")
+        db.session.add(admin)
+        db.session.commit()
+
+        client.post("/auth/login", data={"email": "admin@test.com", "password": "adminpass"})
+
+        match = MatchAnalysis(
+            user_id=admin.id,
+            match_id="NA1_bad_model_admin",
+            champion="Ahri",
+            win=True,
+            kills=5,
+            deaths=2,
+            assists=7,
+            kda=6.0,
+            gold_earned=12000,
+            gold_per_min=400.0,
+            total_damage=20000,
+            damage_per_min=700.0,
+            vision_score=25,
+            cs_total=180,
+            game_duration=30.0,
+            recommendations=[],
+            llm_analysis=None,
+            queue_type="Ranked Solo",
+            participants_json=[
+                {"is_player": True, "team_id": 100, "position": "MIDDLE", "champion": "Ahri"},
+                {"is_player": False, "team_id": 200, "position": "MIDDLE", "champion": "Syndra"},
+            ],
+        )
+        db.session.add(match)
+        db.session.commit()
+
+        with patch(
+            "app.dashboard.routes.get_llm_analysis_detailed",
+            return_value=(None, "Model 'gpt-5.2' on OpenCode Zen is not compatible with /chat/completions."),
+        ):
+            resp = client.post(f"/dashboard/api/matches/{match.id}/ai-analysis", json={"force": True})
+
+        assert resp.status_code == 400
+        payload = resp.get_json()
+        assert payload["trace_id"]
+        assert "not compatible with /chat/completions" in payload["error"].lower()
+        assert "trace id" not in payload["error"].lower()
 
     def test_ai_analysis_stream_returns_cached_done_when_not_forced(self, auth_client, db, user):
         match = MatchAnalysis(
@@ -881,6 +937,9 @@ class TestAiAnalysisRoute:
         assert events[-1]["analysis"] == "cached fallback"
         assert events[-1]["cached"] is True
         assert events[-1]["stale"] is True
+        assert events[-1]["trace_id"]
+        assert "trace id" in events[-1]["error"].lower()
+        assert "timed out" not in events[-1]["error"].lower()
 
     def test_ai_analysis_stream_emits_stale_for_non_general_focus_when_stream_fails_with_cache(self, auth_client, db, user):
         match = MatchAnalysis(
@@ -928,6 +987,9 @@ class TestAiAnalysisRoute:
         assert events[-1]["analysis"] == "cached fallback"
         assert events[-1]["cached"] is True
         assert events[-1]["stale"] is True
+        assert events[-1]["trace_id"]
+        assert "trace id" in events[-1]["error"].lower()
+        assert "timed out" not in events[-1]["error"].lower()
 
     def test_ai_analysis_stream_emits_error_when_stream_fails_without_cache(self, auth_client, db, user):
         match = MatchAnalysis(
@@ -967,6 +1029,9 @@ class TestAiAnalysisRoute:
         assert resp.status_code == 200
         assert events[-1]["type"] == "error"
         assert events[-1]["status"] == 400
+        assert events[-1]["trace_id"]
+        assert "trace id" in events[-1]["error"].lower()
+        assert "not compatible with /chat/completions" not in events[-1]["error"].lower()
 
     def test_ai_analysis_reads_language_specific_cache(self, auth_client, db, user):
         match = MatchAnalysis(


### PR DESCRIPTION
## Summary\n- add trace-id based error handling for AI analysis endpoints so non-admin users receive standard safe messages\n- keep full provider/config error details visible only in admin mode\n- include 	race_id in both sync and streaming error/stale payloads for support/debug correlation\n- remove hardcoded OpenCode fallback model values and require explicit LLM_MODEL compatibility\n- add optional LLM_FALLBACK_MODELS env/config for explicit retry fallback variants\n- update tests for new non-admin/admin error behavior and configurable model fallback behavior\n- update .env.example and README environment docs for the new LLM settings\n\n## Testing\n- python -m pytest tests/\n\nCloses #64