### PR TITLE
feat: add explicit ai status messaging on match detail

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1522,6 +1522,26 @@ html[data-theme="light"] .llm-analysis--rich code {
     box-shadow: 0 0 0 2px var(--accent-glow);
 }
 
+.ai-analysis-status {
+    margin: 2px 0 0;
+    padding-left: 2px;
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    min-height: 1.2em;
+}
+
+.ai-analysis-status.is-loading {
+    color: var(--flash-info-text);
+}
+
+.ai-analysis-status.is-success {
+    color: var(--flash-success-text);
+}
+
+.ai-analysis-status.is-error {
+    color: var(--flash-danger-text);
+}
+
 .match-ai-content,
 .detail-ai-scroll {
     scrollbar-gutter: stable both-edges;
@@ -2455,6 +2475,9 @@ h4,
     .metrics, .stats-grid, .match-stats-grid, .share-grid { grid-template-columns: 1fr; }
     .flash-messages { right: 12px; }
     .theme-toggle { width: 100%; justify-content: center; }
+    .ai-coach-options { flex-wrap: wrap; align-items: stretch; }
+    .ai-focus-label { width: 100%; }
+    .ai-focus-select { max-width: 100%; min-width: 100%; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/templates/dashboard/match_detail.html
+++ b/app/templates/dashboard/match_detail.html
@@ -318,6 +318,7 @@
                     <div id="detail-ai-content" class="detail-ai-scroll">
                         <p class="card-muted">{{ lt('Run AI analysis to generate matchup-specific coaching.', '运行 AI 分析以生成针对该对局的建议。') }}</p>
                     </div>
+                    <p id="detail-ai-status" class="ai-analysis-status" role="status" aria-live="polite">{{ lt('Status: ready to analyze.', '状态：可开始分析。') }}</p>
                 </div>
                 <div class="ai-coach-options">
                     <label class="ai-focus-label" for="ai-focus-select">{{ lt('Coach Focus:', '教练重点：') }}</label>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1406,6 +1406,9 @@ class TestMatchDetailRoute:
         resp = auth_client.get(f"/dashboard/matches/{match.id}")
         assert resp.status_code == 200
         assert b"Gold Total" in resp.data
+        assert b'id="detail-ai-status"' in resp.data
+        assert b'role="status"' in resp.data
+        assert b'aria-live="polite"' in resp.data
 
 
 class TestSettingsPreferencesRoute:


### PR DESCRIPTION
## Summary
- add explicit match-detail AI status messaging (ole=status, ria-live=polite) to reflect loading/success/failure state transitions
- wire status updates through streaming + sync fallback paths so users see clear progress and fallback messaging
- improve small-screen AI controls by wrapping .ai-coach-options and forcing full-width selectors at <=560px
- extend match-detail route test to assert status live-region markup

## Testing
- python -m pytest tests/