### PR TITLE
feat: polish landing mobile hero stack and card breakpoints

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -2496,6 +2496,7 @@ h4,
 
 @media (max-width: 980px) {
     .hero-shell, .workflow-track, .setup-check-grid, .admin-lookup-grid, .steps, .quick-guide-grid, .coach-plan-grid { grid-template-columns: 1fr; }
+    .features-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .team-composition-dual, .composition-split { grid-template-columns: 1fr; }
     .match-box { grid-template-columns: 6px minmax(0, 1fr); }
@@ -2520,7 +2521,25 @@ h4,
 @media (max-width: 560px) {
     .cta-buttons, .match-filter-bar, .match-tab-bar, .detail-tabs, .visual-toggle-bar, .footer-links { width: 100%; }
     .cta-buttons .btn, .match-filter-bar .filter-btn, .match-tab-bar .match-tab-btn, .detail-tabs .detail-tab-btn, .visual-toggle-bar .visual-toggle-btn { flex: 1; }
-    .metrics, .stats-grid, .match-stats-grid, .share-grid { grid-template-columns: 1fr; }
+    .hero-copy .hero-mobile-stack {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+    .hero-copy .cta-buttons .btn { width: 100%; }
+    .hero-copy .cta-buttons .btn-primary {
+        padding: 12px 16px;
+        font-size: 0.9rem;
+    }
+    .hero-copy .signal-pill {
+        width: 100%;
+        justify-content: flex-start;
+        text-transform: none;
+        letter-spacing: 0.04em;
+        white-space: normal;
+        line-height: 1.35;
+    }
+    .features-grid, .steps, .metrics, .stats-grid, .match-stats-grid, .share-grid { grid-template-columns: 1fr; }
     .flash-messages { right: 12px; }
     .theme-toggle { width: 100%; justify-content: center; }
     .ai-coach-options { flex-wrap: wrap; align-items: stretch; }

--- a/app/templates/main/landing.html
+++ b/app/templates/main/landing.html
@@ -9,7 +9,7 @@
             <div class="hero-badge">{{ lt('Built For Deliberate Improvement', '为有意识提升而生') }}</div>
             <h1>{{ lt('Review every match with ', '用') }}<em>{{ lt('clarity', '清晰') }}</em>{{ lt(', not noise', '而非噪音复盘每场对局') }}</h1>
             <p>{{ lt('Track what happened, why it happened, and what to change next queue. LaneScope turns each game into a concise coaching workflow.', '追踪发生了什么、为什么会发生，以及下一局要改什么。LaneScope 将每场对局整理成简洁可执行的复盘流程。') }}</p>
-            <div class="cta-buttons">
+            <div class="cta-buttons hero-mobile-stack">
                 {% if current_user.is_authenticated %}
                     <a href="{{ url_for('dashboard.index') }}" class="btn btn-primary">{{ lt('Open Dashboard', '打开仪表盘') }}</a>
                     <a href="{{ url_for('dashboard.settings') }}" class="btn btn-secondary">{{ lt('Update Settings', '更新设置') }}</a>
@@ -18,7 +18,7 @@
                     <a href="{{ url_for('auth.login') }}" class="btn btn-secondary">{{ lt('Sign In', '登录') }}</a>
                 {% endif %}
             </div>
-            <div class="signal-row">
+            <div class="signal-row hero-mobile-stack">
                 <span class="signal-pill">{{ lt('Automatic Match Sync', '自动同步对局') }}</span>
                 <span class="signal-pill">{{ lt('Role + Matchup Context', '分路 + 对位上下文') }}</span>
                 <span class="signal-pill">{{ lt('One-Action Coaching', '单点可执行建议') }}</span>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -25,6 +25,14 @@ class TestLandingPage:
         resp = client.get("/privacy")
         assert resp.status_code == 200
 
+    def test_landing_has_mobile_stack_hooks_for_hero_actions(self, client):
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert b'class="cta-buttons hero-mobile-stack"' in resp.data
+        assert b'class="signal-row hero-mobile-stack"' in resp.data
+        assert b'class="features-grid feature-min-grid"' in resp.data
+        assert b'class="steps"' in resp.data
+
 
 class TestRegister:
     def test_register_page_loads(self, client):


### PR DESCRIPTION
## Summary
- improve landing-page mobile flow by stacking hero CTA + signal rows into a stable single-column layout at <=560px
- keep primary action visually dominant on narrow screens with stronger primary-button sizing in hero copy
- make signal pills wrap safely on small screens to reduce overflow risk
- make breakpoints explicit for card rhythm: features remain 2-up at <=980 and collapse to 1-up at <=560
- add regression test asserting landing template includes mobile-stack class hooks for hero actions/signals

## Testing
- python -m pytest tests/