### PR TITLE
feat: add remember-me option to login flow

### DIFF
--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, SubmitField
+from wtforms import BooleanField, StringField, PasswordField, SubmitField
 from wtforms.validators import DataRequired, Email, Length, EqualTo, ValidationError
 from app.models import User
 
@@ -10,6 +10,7 @@ class LoginForm(FlaskForm):
         validators=[DataRequired(message='validation.email_invalid'), Email(message='validation.email_invalid')],
     )
     password = PasswordField('form.password', validators=[DataRequired(message='validation.password_required')])
+    remember = BooleanField('Remember me')
     submit = SubmitField('form.sign_in')
 
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -17,7 +17,7 @@ def login():
     if form.validate_on_submit():
         user = User.query.filter_by(email=form.email.data.lower()).first()
         if user and user.check_password(form.password.data):
-            login_user(user)
+            login_user(user, remember=bool(form.remember.data))
             next_page = request.args.get('next')
             flash(t('flash.welcome_back'), 'success')
             return redirect(next_page or url_for('dashboard.index'))

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -23,6 +23,10 @@
                     <div class="error">{{ t(error) }}</div>
                 {% endfor %}
             </div>
+            <div class="form-check">
+                {{ form.remember() }}
+                <label for="{{ form.remember.id }}">{{ lt('Remember me on this device', '在此设备上保持登录') }}</label>
+            </div>
             <div class="form-actions">
                 <button type="submit" class="btn btn-primary">{{ lt('Sign In', '登录') }}</button>
             </div>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -92,6 +92,33 @@ class TestLogin:
         }, follow_redirects=True)
         assert resp.status_code == 200
 
+    def test_login_with_remember_sets_remember_cookie(self, client, user):
+        resp = client.post(
+            "/auth/login",
+            data={
+                "email": "test@example.com",
+                "password": "testpass123",
+                "remember": "y",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        cookies = resp.headers.getlist("Set-Cookie")
+        assert any("remember_token=" in cookie for cookie in cookies)
+
+    def test_login_without_remember_does_not_set_remember_cookie(self, client, user):
+        resp = client.post(
+            "/auth/login",
+            data={
+                "email": "test@example.com",
+                "password": "testpass123",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        cookies = resp.headers.getlist("Set-Cookie")
+        assert not any("remember_token=" in cookie for cookie in cookies)
+
     def test_login_wrong_password(self, client, user):
         resp = client.post("/auth/login", data={
             "email": "test@example.com",


### PR DESCRIPTION
## Summary
- add emember field to login form and expose a remember-me checkbox in the login UI
- pass remember preference to login_user(..., remember=...) so session persistence is user-controlled
- add route tests that verify remember cookie behavior for selected vs unselected login

## Testing
- python -m pytest tests/