### PR TITLE
feat: harden landing token-row overflow guard

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -736,10 +736,12 @@ textarea:focus-visible {
 }
 
 .cta-buttons,
-.signal-row {
+.signal-row,
+.hero-signal {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: clamp(0.25rem, 1vw, 0.6rem);
+    max-width: 100%;
 }
 
 .hero-cta-rail {
@@ -778,12 +780,10 @@ textarea:focus-visible {
     min-width: 0;
 }
 
-.hero-token-line .signal-row {
+.hero-token-line .signal-row,
+.hero-token-line .hero-signal {
     width: 100%;
     max-width: 100%;
-    display: flex;
-    flex-wrap: wrap;
-    gap: clamp(8px, 1.4vw, 10px);
     align-items: stretch;
 }
 
@@ -791,7 +791,9 @@ textarea:focus-visible {
     margin-top: 0;
 }
 
-.hero-token-line .hero-token {
+.hero-token-line .signal-pill.hero-token,
+.signal-row .hero-signal-pill.hero-token,
+.signal-pill.hero-token {
     flex: 0 1 auto;
     min-width: 0;
     max-width: 100%;
@@ -803,6 +805,10 @@ textarea:focus-visible {
 .hero-token-line .hero-signal-pill {
     min-width: 0;
     width: auto;
+}
+
+.hero-token-line .hero-signal-pill {
+    max-width: 100%;
 }
 
 .signal-pill {

--- a/app/templates/main/landing.html
+++ b/app/templates/main/landing.html
@@ -54,7 +54,7 @@
                 </div>
             </div>
             <div class="hero-token-line">
-                <div class="signal-row hero-mobile-stack">
+                <div class="signal-row hero-signal hero-mobile-stack">
                     <span class="signal-pill hero-signal-pill hero-token">{{ lt('Automatic Match Sync', '自动同步对局') }}</span>
                     <span class="signal-pill hero-signal-pill hero-token">{{ lt('Role + Matchup Context', '分路 + 对位上下文') }}</span>
                     <span class="signal-pill hero-signal-pill hero-token">{{ lt('One-Action Coaching', '单点可执行建议') }}</span>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -37,7 +37,7 @@ class TestLandingPage:
         assert b'class="hero-cta-helper" id="landing-cta-support" data-helper-role="secondary-path"' in resp.data
         assert b'class="hero-tertiary-link hero-cta-helper-link"' in resp.data
         assert b'class="hero-token-line"' in resp.data
-        assert b'class="signal-row hero-mobile-stack"' in resp.data
+        assert b'class="signal-row hero-signal hero-mobile-stack"' in resp.data
         assert b'class="signal-pill hero-signal-pill hero-token"' in resp.data
         assert b'class="features-grid feature-min-grid feature-rhythm-grid"' in resp.data
         assert b'class="steps steps-rhythm-grid"' in resp.data


### PR DESCRIPTION
## Summary
- Implement #3x12 from the #3x UX Loop backlog: deterministic overflow guard for landing hero token chips.
- Added explicit .hero-token-line + .hero-signal class contract and token row flex/wrap constraints.
- Updated landing/overflow CSS to keep .signal-row, .hero-signal, and token pills width-clipped and wrap-safe.
- Added route test assertions for the new deterministic token-row class hooks.

## Validation
- python -m pytest tests/