### PR TITLE
Improve dashboard queue filter semantics

### DIFF
--- a/app/i18n.py
+++ b/app/i18n.py
@@ -587,6 +587,7 @@ def js_i18n_payload(locale: str | None = None) -> dict:
             'analyzing': lt('Analyzing...', '分析中...', locale=lang),
             'noMatches': lt('No matches found for this filter.', '该筛选条件下暂无对局数据。', locale=lang),
             'showingMatches': lt('Showing {displayed} of {total} matches', '显示 {displayed} / {total} 场对局', locale=lang),
+            'showingMatchesInQueue': lt('Showing {displayed} of {total} matches in {queue}', '在 {queue} 中显示 {displayed} / {total} 场对局', locale=lang),
             'filterTabWithCount': lt('{queue}: {count} matches', '{queue}：{count} 场', locale=lang),
             'noMatchesHelp': lt('Connect your Riot account in settings and sync recent matches to populate this queue.', '请先在设置中绑定 Riot 账号并同步最近对局，以填充该队列。', locale=lang),
             'goSettings': lt('Go to Settings', '前往设置', locale=lang),

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -736,10 +736,12 @@ textarea:focus-visible {
 }
 
 .cta-buttons,
-.signal-row {
+.signal-row,
+.hero-signal {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
+    gap: clamp(0.25rem, 1vw, 0.6rem);
+    max-width: 100%;
 }
 
 .hero-cta-rail {
@@ -778,12 +780,10 @@ textarea:focus-visible {
     min-width: 0;
 }
 
-.hero-token-line .signal-row {
+.hero-token-line .signal-row,
+.hero-token-line .hero-signal {
     width: 100%;
     max-width: 100%;
-    display: flex;
-    flex-wrap: wrap;
-    gap: clamp(8px, 1.4vw, 10px);
     align-items: stretch;
 }
 
@@ -791,7 +791,9 @@ textarea:focus-visible {
     margin-top: 0;
 }
 
-.hero-token-line .hero-token {
+.hero-token-line .signal-pill.hero-token,
+.signal-row .hero-signal-pill.hero-token,
+.signal-pill.hero-token {
     flex: 0 1 auto;
     min-width: 0;
     max-width: 100%;
@@ -803,6 +805,10 @@ textarea:focus-visible {
 .hero-token-line .hero-signal-pill {
     min-width: 0;
     width: auto;
+}
+
+.hero-token-line .hero-signal-pill {
+    max-width: 100%;
 }
 
 .signal-pill {

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -879,7 +879,14 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
-    function setMatchFilterSummary(displayed, total) {
+    function resolveActiveFilterLabel() {
+        if (!filterBar) return '';
+        var activeButton = filterBar.querySelector('.filter-btn[aria-selected="true"]') || filterBar.querySelector('.filter-btn.active');
+        if (!activeButton) return '';
+        return (activeButton.getAttribute('data-label-base') || activeButton.textContent || '').trim();
+    }
+
+    function setMatchFilterSummary(displayed, total, queueLabel) {
         if (!filterSummary) return;
         var displayedCount = Number(displayed);
         var totalCount = Number(total);
@@ -889,10 +896,19 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!Number.isFinite(totalCount) || totalCount < displayedCount) {
             totalCount = displayedCount;
         }
-        var template = txt('showingMatches', 'Showing {displayed} of {total} matches');
+        var label = (queueLabel || resolveActiveFilterLabel() || txt('all', 'All')).trim();
+        var template = txt('showingMatchesInQueue', 'Showing {displayed} of {total} matches in {queue}');
+        if (template.indexOf('{queue}') < 0) {
+            template = txt('showingMatches', 'Showing {displayed} of {total} matches')
+                .replace('{displayed}', String(displayedCount))
+                .replace('{total}', String(totalCount));
+            filterSummary.textContent = template;
+            return;
+        }
         filterSummary.textContent = template
             .replace('{displayed}', String(displayedCount))
-            .replace('{total}', String(totalCount));
+            .replace('{total}', String(totalCount))
+            .replace('{queue}', label);
     }
 
     function normalizeBadgeCount(total) {
@@ -1099,11 +1115,16 @@ document.addEventListener('DOMContentLoaded', function () {
                 }
             }
 
+            function activateQueueFilter(btn, focus) {
+                if (!btn) return;
+                setActiveQueueFilter(btn, focus);
+                filterByQueue(btn.getAttribute('data-queue'), btn);
+            }
+
             filterBar.addEventListener('click', function (e) {
                 var btn = e.target.closest('.filter-btn');
                 if (!btn) return;
-                setActiveQueueFilter(btn, false);
-                filterByQueue(btn.getAttribute('data-queue'), btn);
+                activateQueueFilter(btn, false);
             });
 
             filterBar.addEventListener('keydown', function (e) {
@@ -1112,6 +1133,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 var buttons = Array.prototype.slice.call(filterBar.querySelectorAll('.filter-btn'));
                 var currentIndex = buttons.indexOf(current);
                 if (currentIndex < 0) return;
+
+                if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+                    e.preventDefault();
+                    activateQueueFilter(current, false);
+                    return;
+                }
 
                 var nextIndex = currentIndex;
                 if (e.key === 'ArrowRight') {
@@ -1128,8 +1155,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
                 e.preventDefault();
                 var next = buttons[nextIndex];
-                setActiveQueueFilter(next, true);
-                filterByQueue(next.getAttribute('data-queue'), next);
+                activateQueueFilter(next, true);
             });
         }
 

--- a/app/templates/main/landing.html
+++ b/app/templates/main/landing.html
@@ -54,7 +54,7 @@
                 </div>
             </div>
             <div class="hero-token-line">
-                <div class="signal-row hero-mobile-stack">
+                <div class="signal-row hero-signal hero-mobile-stack">
                     <span class="signal-pill hero-signal-pill hero-token">{{ lt('Automatic Match Sync', '自动同步对局') }}</span>
                     <span class="signal-pill hero-signal-pill hero-token">{{ lt('Role + Matchup Context', '分路 + 对位上下文') }}</span>
                     <span class="signal-pill hero-signal-pill hero-token">{{ lt('One-Action Coaching', '单点可执行建议') }}</span>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -37,7 +37,7 @@ class TestLandingPage:
         assert b'class="hero-cta-helper" id="landing-cta-support" data-helper-role="secondary-path"' in resp.data
         assert b'class="hero-tertiary-link hero-cta-helper-link"' in resp.data
         assert b'class="hero-token-line"' in resp.data
-        assert b'class="signal-row hero-mobile-stack"' in resp.data
+        assert b'class="signal-row hero-signal hero-mobile-stack"' in resp.data
         assert b'class="signal-pill hero-signal-pill hero-token"' in resp.data
         assert b'class="features-grid feature-min-grid feature-rhythm-grid"' in resp.data
         assert b'class="steps steps-rhythm-grid"' in resp.data

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 ﻿"""Tests for auth and basic routes."""
 
 import json
+from pathlib import Path
 from unittest.mock import patch
 
 from app.dashboard.routes import sync_recent_matches
@@ -246,6 +247,14 @@ class TestDashboardAccess:
         assert b'role="tab"' in resp.data
         assert b'data-queue="" role="tab" aria-selected="true" aria-controls="match-list" tabindex="0"' in resp.data
         assert b'data-queue="Ranked Solo" role="tab" aria-selected="false" aria-controls="match-list" tabindex="-1"' in resp.data
+        assert b'"showingMatchesInQueue"' in resp.data
+
+    def test_dashboard_queue_filter_keyboard_contracts_in_frontend_js(self):
+        js = Path("app/static/js/main.js").read_text(encoding="utf-8")
+        assert "e.key === 'Enter'" in js
+        assert "e.key === ' '" in js
+        assert "e.key === 'ArrowRight'" in js
+        assert "showingMatchesInQueue" in js
 
 
 class TestSyncRecentMatches:


### PR DESCRIPTION
## Summary
- Add queue-context-aware match filter summary text via new i18n key showingMatchesInQueue.
- Add Enter/Space (and Spacebar) activation handling for match queue filter keyboard interactions while keeping arrow navigation.

## Testing
- python -m pytest tests/